### PR TITLE
Handle locale link manually, as NextJS excludes the default language …

### DIFF
--- a/frontend/src/components/LanguageSelect.tsx
+++ b/frontend/src/components/LanguageSelect.tsx
@@ -34,7 +34,7 @@ const LanguageSelect = () => {
       <div className="dialog absolute center ma2 measure aspect-ratio--object">
         <div className="list flex flex-column flex-wrap bg-near-white br2 pa2">
           {locales.map((v: string) => (
-            <Link key={v} href={asPath} locale={v}>
+            <Link key={v} href={'/' + v + asPath} locale={false}>
               <a
                 className="link br2 black pa1 hover-bg-black-20"
                 onClick={() => setShowLocales(false)}


### PR DESCRIPTION
NextJS currently excludes /en from the English language link path as it is the default language. This causes issues if your default language isn't English, as your browser default language is used (if available) if the language is omitted from the path. This PR ensures that the English language select link always refers to English, regardless if the user's default language isn't English.