### PR TITLE
use open.mp png logo instead of svg in FAQ page

### DIFF
--- a/frontend/src/pages/faq.tsx
+++ b/frontend/src/pages/faq.tsx
@@ -1,4 +1,4 @@
-import { Wordmark } from "src/components/Branding";
+import Image from "next/image";
 import { Content } from "src/mdx-helpers/content";
 import { markdownCSR } from "src/mdx-helpers/csr";
 
@@ -9,7 +9,11 @@ type Props = {
 const Page = ({ content }: Props) => (
   <section className="pa0 ma0 center">
     <div className="mw8 center">
-      <Wordmark />
+      <Image
+        src="https://assets.open.mp/assets/images/assets/wordmark-light-mono.png"
+        width={1660}
+        height={560}
+      />
     </div>
 
     <article className="pa0 ma0">


### PR DESCRIPTION
since some browsers (like Chrome) have some difficulties with rendering <mask> in SVG, use png for FAQ page like homepage 