### PR TITLE
Attempt to fix large page renders (animations, etc)

### DIFF
--- a/frontend/src/pages/docs/[[...path]].tsx
+++ b/frontend/src/pages/docs/[[...path]].tsx
@@ -72,6 +72,7 @@ import admonitions from "remark-admonitions";
 import { renderToString } from "src/mdx-helpers/ssr";
 import { readLocaleDocs } from "src/utils/content";
 import Search from "src/components/Search";
+import { statSync } from "fs";
 
 export async function getStaticProps(
   context: GetStaticPropsContext<{ path: string[] }>
@@ -110,6 +111,7 @@ export async function getStaticProps(
 export async function getStaticPaths() {
   const paths = glob
     .sync("../docs/**/*.md") // read docs from the repo root
+    .filter((v: string) => statSync(v).size > 60000) // only build large pages
     .map((v: string) => "/" + v.slice(3, v.length - extname(v).length))
     .map((v: string) => (v.endsWith("index") ? v.slice(0, v.length - 5) : v));
 

--- a/frontend/src/pages/docs/[[...path]].tsx
+++ b/frontend/src/pages/docs/[[...path]].tsx
@@ -117,7 +117,7 @@ export async function getStaticPaths() {
 
   return {
     paths: paths,
-    fallback: true,
+    fallback: "blocking",
   };
 }
 

--- a/frontend/src/pages/docs/[[...path]].tsx
+++ b/frontend/src/pages/docs/[[...path]].tsx
@@ -63,8 +63,10 @@ const Page = (props: Props) => {
 // Server side
 // -
 
+import { extname } from "path";
 import { GetStaticPropsContext, GetStaticPropsResult } from "next";
 import matter from "gray-matter";
+import glob from "glob";
 import admonitions from "remark-admonitions";
 
 import { renderToString } from "src/mdx-helpers/ssr";
@@ -106,9 +108,14 @@ export async function getStaticProps(
 }
 
 export async function getStaticPaths() {
+  const paths = glob
+    .sync("../docs/**/*.md") // read docs from the repo root
+    .map((v: string) => "/" + v.slice(3, v.length - extname(v).length))
+    .map((v: string) => (v.endsWith("index") ? v.slice(0, v.length - 5) : v));
+
   return {
-    paths: [],
-    fallback: "blocking",
+    paths: paths,
+    fallback: true,
   };
 }
 

--- a/frontend/src/pages/docs/[[...path]].tsx
+++ b/frontend/src/pages/docs/[[...path]].tsx
@@ -108,7 +108,7 @@ export async function getStaticProps(
 export async function getStaticPaths() {
   return {
     paths: [],
-    fallback: true,
+    fallback: "blocking",
   };
 }
 


### PR DESCRIPTION
use blocking fallback for docs pages