### PR TITLE
ignore CI for server when there are changes to frontend or docs

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - "*"
       - "!master"
+    paths-ignore:
+      - "docs/**"
+      - "frontend/**"
 
 jobs:
   main:

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - "docs/**"
+      - "frontend/**"
 
 jobs:
   main:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,14 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - "docs/**"
+      - "frontend/**"
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "frontend/**"
 
 jobs:
   test:


### PR DESCRIPTION
Testing and building the backend is pointless when making changes to docs or frontend code. This will save some build minutes.

Fixes #158