### PR TITLE
Fix static translations

### DIFF
--- a/frontend/scripts/gentree.js
+++ b/frontend/scripts/gentree.js
@@ -35,11 +35,6 @@ function parseDir(filename) {
     }
     // it's a directory inside `docs` folder
     else {
-      // ignore translations, these are handled automatically
-      if (path.basename(filename) === "translations") {
-        return null;
-      }
-
       info.type = "category";
       let catName = path.basename(filename);
 

--- a/frontend/scripts/gentree.js
+++ b/frontend/scripts/gentree.js
@@ -35,6 +35,11 @@ function parseDir(filename) {
     }
     // it's a directory inside `docs` folder
     else {
+      // ignore translations, these are handled automatically
+      if (path.basename(filename) === "translations") {
+        return null;
+      }
+
       info.type = "category";
       let catName = path.basename(filename);
 

--- a/frontend/src/pages/docs/[[...path]].tsx
+++ b/frontend/src/pages/docs/[[...path]].tsx
@@ -101,11 +101,7 @@ export async function getStaticProps(
   const route = context?.params?.path || ["index"];
 
   let result: { source: string; fallback: boolean };
-  const path = route
-    // remove /docs/ part of the route
-    .slice(1)
-    // join together as a path
-    .join("/");
+  const path = route.join("/");
   try {
     result = await readLocaleDocs(path, locale);
   } catch (e) {

--- a/frontend/src/pages/docs/[[...path]].tsx
+++ b/frontend/src/pages/docs/[[...path]].tsx
@@ -148,14 +148,14 @@ export async function getStaticPaths(
     // Filter out category content pages
     filter((v: string) => !v.endsWith("_.md")),
 
-    // Chop off the `../` and the extension, and prefix with `/`
-    map((v: string) => v.slice(3, v.length - extname(v).length)),
+    // Chop off the `../docs/` and the extension
+    map((v: string) => v.slice(8, v.length - extname(v).length)),
 
     // slices off "index" from pages so they lead to the base path
     map((v: string) => (v.endsWith("index") ? v.slice(0, v.length - 5) : v)),
 
     // Add the docs base path (open.mp/docs)
-    concat(["docs"]),
+    concat([""]),
 
     // Transform the paths into Path objects for "en" locale
     map((v: string) => ({

--- a/frontend/src/pages/docs/[[...path]].tsx
+++ b/frontend/src/pages/docs/[[...path]].tsx
@@ -150,8 +150,8 @@ export async function getStaticPaths(
     // slices off "index" from pages so they lead to the base path
     map((v: string) => (v.endsWith("index") ? v.slice(0, v.length - 5) : v)),
 
-    // Add the docs base path
-    concat(["/docs/"]),
+    // Add the docs base path (open.mp/docs)
+    concat(["docs"]),
 
     // Transform the paths into a matrix of Path objects for each locale
     map((v: string) =>

--- a/frontend/src/pages/docs/[[...path]].tsx
+++ b/frontend/src/pages/docs/[[...path]].tsx
@@ -157,16 +157,13 @@ export async function getStaticPaths(
     // Add the docs base path (open.mp/docs)
     concat(["docs"]),
 
-    // Transform the paths into a matrix of Path objects for each locale
-    map((v: string) =>
-      map((l: string) => ({
-        params: { path: v.split("/") },
-        locale: l,
-      }))(ctx.locales)
-    ),
-
-    // Flatten the above structure back to an array of Path items
-    flatten
+    // Transform the paths into Path objects for "en" locale
+    map((v: string) => ({
+      params: {
+        path: v.split("/"),
+      },
+      locale: "en",
+    }))
   )(all);
 
   return {

--- a/frontend/src/pages/docs/[[...path]].tsx
+++ b/frontend/src/pages/docs/[[...path]].tsx
@@ -78,7 +78,12 @@ const Page = (props: Props) => {
 // -
 
 import { extname } from "path";
-import { GetStaticPropsContext, GetStaticPropsResult } from "next";
+import {
+  GetStaticPathsContext,
+  GetStaticPathsResult,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from "next";
 import matter from "gray-matter";
 import glob from "glob";
 import admonitions from "remark-admonitions";
@@ -86,7 +91,7 @@ import admonitions from "remark-admonitions";
 import { renderToString } from "src/mdx-helpers/ssr";
 import { readLocaleDocs } from "src/utils/content";
 import Search from "src/components/Search";
-import { concat } from "lodash/fp";
+import { concat, filter, flatten, flow, map } from "lodash/fp";
 import { Components } from "@mdx-js/react";
 
 export async function getStaticProps(
@@ -123,14 +128,42 @@ export async function getStaticProps(
   };
 }
 
-export async function getStaticPaths() {
-  const paths = concat(["/docs/"])(
-    glob
-      .sync("../docs/**/*.md") // read docs from the repo root
-      // .filter((v: string) => statSync(v).size > 60000) // only build large pages
-      .map((v: string) => "/" + v.slice(3, v.length - extname(v).length))
-      .map((v: string) => (v.endsWith("index") ? v.slice(0, v.length - 5) : v))
-  );
+export async function getStaticPaths(
+  ctx: GetStaticPathsContext
+): Promise<GetStaticPathsResult> {
+  type P = { path: string[] };
+  type Path = { params: P; locale?: string };
+
+  // read docs from the repo root
+  const all = glob.sync("../docs/**/*.md");
+
+  const paths: Array<Path> = flow(
+    // Filter out translations directory - these are handled separately
+    filter((v: string) => !v.startsWith("../docs/translations")),
+
+    // Filter out category content pages
+    filter((v: string) => !v.endsWith("_.md")),
+
+    // Chop off the `../` and the extension, and prefix with `/`
+    map((v: string) => v.slice(3, v.length - extname(v).length)),
+
+    // slices off "index" from pages so they lead to the base path
+    map((v: string) => (v.endsWith("index") ? v.slice(0, v.length - 5) : v)),
+
+    // Add the docs base path
+    concat(["/docs/"]),
+
+    // Transform the paths into a matrix of Path objects for each locale
+    map((v: string) =>
+      map((l: string) => ({
+        params: { path: v.split("/") },
+        locale: l,
+      }))(ctx.locales)
+    ),
+
+    // Flatten the above structure back to an array of Path items
+    flatten
+  )(all);
 
   return {
     paths: paths,

--- a/frontend/src/pages/docs/[[...path]].tsx
+++ b/frontend/src/pages/docs/[[...path]].tsx
@@ -101,7 +101,11 @@ export async function getStaticProps(
   const route = context?.params?.path || ["index"];
 
   let result: { source: string; fallback: boolean };
-  const path = route.join("/");
+  const path = route
+    // remove /docs/ part of the route
+    .slice(1)
+    // join together as a path
+    .join("/");
   try {
     result = await readLocaleDocs(path, locale);
   } catch (e) {

--- a/frontend/src/utils/content.ts
+++ b/frontend/src/utils/content.ts
@@ -60,10 +60,6 @@ export const exists = (path: string): boolean => {
 export const readMdFromLocal = async (
   path: string
 ): Promise<string | undefined> => {
-  if (path === "") {
-    path = "index";
-  }
-
   const path_mdx = path + ".mdx";
   const path_md = path + ".md";
 
@@ -83,10 +79,6 @@ export const readMdFromLocal = async (
 export const readMdFromAPI = async (
   path: string
 ): Promise<string | undefined> => {
-  if (path === "") {
-    path = "index";
-  }
-
   const path_mdx = path + ".mdx";
   const path_md = path + ".md";
 
@@ -133,6 +125,10 @@ export const readLocaleDocs = async (
   name: string,
   locale?: string
 ): Promise<RawContent> => {
+  if (name === "") {
+    name = "index";
+  }
+
   let withLocale = "../docs/" + name;
   if (locale && locale != "en") {
     withLocale = `../docs/translations/${locale}/${name}`;

--- a/frontend/src/utils/content.ts
+++ b/frontend/src/utils/content.ts
@@ -145,5 +145,10 @@ export const readLocaleDocs = async (
     return { source, fallback: true };
   }
 
+  source = await readMdFromAPI(name);
+  if (source !== undefined) {
+    return { source, fallback: true };
+  }
+
   throw new Error(`Not found (${name})`);
 };

--- a/frontend/src/utils/content.ts
+++ b/frontend/src/utils/content.ts
@@ -133,17 +133,18 @@ export const readLocaleDocs = async (
   name: string,
   locale?: string
 ): Promise<RawContent> => {
-  let fullName = name;
+  let withLocale = "../docs/" + name;
   if (locale && locale != "en") {
-    fullName = `translations/${locale}/${name}`;
+    withLocale = `../docs/translations/${locale}/${name}`;
   }
 
-  let source = await readMdFromLocal("../docs/" + fullName);
+  let source = await readMdFromLocal(withLocale);
   if (source !== undefined) {
     return { source, fallback: false };
   }
 
-  source = await readMdFromLocal("../docs/" + name);
+  const fallbackPath = "../docs/" + name;
+  source = await readMdFromLocal(fallbackPath);
   if (source !== undefined) {
     return { source, fallback: true };
   }


### PR DESCRIPTION
This change updates the /docs/ `getStaticPaths` function to return a list of all docs pages for all languages.

This drastically increases the number of pages because of the multiplication against locales. 20,000+ pages at the time of commit.

This may have an impact on the output size and is mostly an experiment. There needs to be a better solution long-term.