### PR TITLE
Fixed the Archive.org link.

### DIFF
--- a/frontend/content/en/missing-sites.mdx
+++ b/frontend/content/en/missing-sites.mdx
@@ -27,7 +27,7 @@ The Forum and the Wiki are probably not coming back. It would be great to be wro
 
 ## Alternatives
 
-For now, the wiki content is still accessible using [the Archive.org copies](https://web.archive.org/web/20200909122444/https://wiki.sa-mp.com/).
+For now, the wiki content is still accessible using [the Archive.org copies](http://web-old.archive.org/web/20200314132548/https://wiki.sa-mp.com/wiki/Main_Page).
 
 This is obviously not a great long-term solution. These pages take a long time to load and it stresses the Archive.org's service (which is already underfunded and a very important part of internet history).
 


### PR DESCRIPTION
The old link was taking the users to a page that said "Sorry the URL has been excluded from the WayBack Machine". This new link runs on Archive.org's 'web-old' subdomain, which works.

![image](https://user-images.githubusercontent.com/28570807/104760284-d1ebb480-5769-11eb-856a-eac265d538e7.png)
![image](https://user-images.githubusercontent.com/28570807/104760305-d6b06880-5769-11eb-9923-88fcab2ec789.png)
![image](https://user-images.githubusercontent.com/28570807/104760348-e9c33880-5769-11eb-825a-33cfef105a8c.png)
