### PR TITLE
Fix locale docs

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -6,17 +6,21 @@ const generateCache = require("./scripts/gencache");
 
 generateCache();
 
-module.exports = {
-  env: {
-    tree: parseDir("../docs"),
-  },
-  i18n: {
-    locales: fs
-      .readdirSync("content")
-      .filter((v) => fs.statSync(path.join("content", v)).isDirectory()),
-    defaultLocale: "en",
-  },
-  images: {
-    domains: ["assets.open.mp"],
-  },
+module.exports = (phase) => {
+  console.log("Phase:", phase);
+  return {
+    env: {
+      phase,
+      tree: parseDir("../docs"),
+    },
+    i18n: {
+      locales: fs
+        .readdirSync("content")
+        .filter((v) => fs.statSync(path.join("content", v)).isDirectory()),
+      defaultLocale: "en",
+    },
+    images: {
+      domains: ["assets.open.mp"],
+    },
+  };
 };

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -9,8 +9,8 @@ generateCache();
 module.exports = (phase) => {
   console.log("Phase:", phase);
   return {
+    serverRuntimeConfig: { phase },
     env: {
-      phase,
       tree: parseDir("../docs"),
     },
     i18n: {

--- a/frontend/src/utils/content.ts
+++ b/frontend/src/utils/content.ts
@@ -199,6 +199,7 @@ export const readLocaleDocs = async (
   locale?: string
 ): Promise<RawContent> => {
   const { serverRuntimeConfig } = getConfig();
+  console.log("[Request] Phase:", serverRuntimeConfig.phase);
   // If dev mode (`npm run dev`) or a production build (`npm run build`) then
   // read docs from the local filesystem.
   if (

--- a/frontend/src/utils/content.ts
+++ b/frontend/src/utils/content.ts
@@ -203,8 +203,9 @@ export const readLocaleDocs = async (
   // If dev mode (`npm run dev`) or a production build (`npm run build`) then
   // read docs from the local filesystem.
   if (
-    serverRuntimeConfig.phase === PHASE_DEVELOPMENT_SERVER ||
-    serverRuntimeConfig.phase === PHASE_PRODUCTION_BUILD
+    (serverRuntimeConfig.phase === PHASE_DEVELOPMENT_SERVER ||
+      serverRuntimeConfig.phase === PHASE_PRODUCTION_BUILD) &&
+    process.env.VERCEL !== "1"
   ) {
     // If you want to simulate how the production site fetches content, comment
     // out the line below so local files aren't used to render docs pages.

--- a/frontend/src/utils/content.ts
+++ b/frontend/src/utils/content.ts
@@ -3,6 +3,7 @@
 // and list files/locales.
 import { statSync, readFileSync, readdirSync } from "fs";
 import { join, resolve } from "path";
+import getConfig from "next/config";
 import {
   PHASE_DEVELOPMENT_SERVER,
   PHASE_PRODUCTION_BUILD,
@@ -197,12 +198,15 @@ export const readLocaleDocs = async (
   name: string,
   locale?: string
 ): Promise<RawContent> => {
+  const { serverRuntimeConfig } = getConfig();
   // If dev mode (`npm run dev`) or a production build (`npm run build`) then
   // read docs from the local filesystem.
   if (
-    process.env.phase === PHASE_DEVELOPMENT_SERVER ||
-    process.env.phase === PHASE_PRODUCTION_BUILD
+    serverRuntimeConfig.phase === PHASE_DEVELOPMENT_SERVER ||
+    serverRuntimeConfig.phase === PHASE_PRODUCTION_BUILD
   ) {
+    // If you want to simulate how the production site fetches content, comment
+    // out the line below so local files aren't used to render docs pages.
     return await readLocaleDocsDevMode(name, locale);
   }
 

--- a/frontend/src/utils/content.ts
+++ b/frontend/src/utils/content.ts
@@ -225,6 +225,12 @@ export const readLocaleDocs = async (
     return { source, fallback: false };
   }
 
+  //Next, try the English version as a fallback.
+  source = await readMdFromAPI(name);
+  if (source !== undefined) {
+    return { source, fallback: true };
+  }
+
   // Finally, try the API for the directory listing or the raw file. This is
   // usually hit for when a category page is request for a non-en locale.
   // In dev mode, this is never hit because the local files are found but in


### PR DESCRIPTION
moved local filesystem related content code into a separate function and ensured it's only called for dev and static builds