### PR TITLE
remove WWW-Authenticate: Basic header

### DIFF
--- a/server/src/web/web.go
+++ b/server/src/web/web.go
@@ -39,7 +39,6 @@ func StatusInternalServerError(w http.ResponseWriter, err error) {
 
 // StatusUnauthorized writes a pretty error
 func StatusUnauthorized(w http.ResponseWriter, err error) {
-	w.Header().Add("WWW-Authenticate", "Basic")
 	w.WriteHeader(http.StatusUnauthorized)
 	errToWriter(w, err)
 }


### PR DESCRIPTION
This was causing unexpected basic auth dialogue prompts on the client for `fetch` calls.