### PR TITLE
Fix math docs

### DIFF
--- a/docs/scripting/functions/acos.md
+++ b/docs/scripting/functions/acos.md
@@ -1,6 +1,6 @@
 ---
 title: acos
-description: Get the inversed value of an arc cosine in radians.
+description: Get the inversed value of a cosine in degrees.
 tags: ["math"]
 ---
 
@@ -8,15 +8,15 @@ tags: ["math"]
 
 ## Description
 
-Get the inversed value of an arc cosine in radians.
+Get the inversed value of a cosine in degrees. In trigonometrics, arc cosine is the inverse operation of cosine.
 
-| Name        | Description              |
-| ----------- | ------------------------ |
-| Float:value | the input in arc cosine. |
+| Name        | Description                                                  |
+| ----------- | ------------------------------------------------------------ |
+| Float:value | value whose arc cosine is computed, in the interval [-1,+1]. |
 
 ## Returns
 
-Principal arc cosine of x, in the interval [0, pi] radians. One radian is equivalent to 180/PI degrees.
+The angle in degrees, in the interval [0.0,180.0].
 
 ## Examples
 
@@ -27,9 +27,9 @@ public OnGameModeInit()
 {
     new Float:param, Float:result;
     param = 0.5;
-    result = acos (param) * 180.0 / PI;
-    printf ("The arc cosine of %f is %f degrees.\n", param, result);
-    return 0;
+    result = acos(param);
+    printf("The arc cosine of %f is %f degrees.", param, result);
+    return 1;
 }
 ```
 
@@ -38,3 +38,6 @@ public OnGameModeInit()
 - [floatsin](floatsin): Get the sine from a specific angle.
 - [floatcos](floatcos): Get the cosine from a specific angle.
 - [floattan](floattan): Get the tangent from a specific angle.
+- [asin](asin): Get the inversed value of a sine in degrees.
+- [atan](atan): Get the inversed value of a tangent in degrees.
+- [atan2](atan2): Get the multi-valued inversed value of a tangent in degrees.

--- a/docs/scripting/functions/asin.md
+++ b/docs/scripting/functions/asin.md
@@ -1,6 +1,6 @@
 ---
 title: asin
-description: Get the inversed value of an arc sine in radians
+description: Get the inversed value of a sine in degrees.
 tags: ["math"]
 ---
 
@@ -8,15 +8,15 @@ tags: ["math"]
 
 ## Description
 
-Get the inversed value of an arc sine in radians.
+Get the inversed value of a sine in degrees. In trigonometrics, arc sine is the inverse operation of sine.
 
-| Name        | Description            |
-| ----------- | ---------------------- |
-| Float:value | the input in arc sine. |
+| Name        | Description                                                |
+| ----------- | ---------------------------------------------------------- |
+| Float:value | value whose arc sine is computed, in the interval [-1,+1]. |
 
 ## Returns
 
-Value whose arc sine is computed, in the interval [-1,+1]. If the argument is out of this interval, a domain error occurs.
+The angle in degrees, in the interval [-90.0,+90.0].
 
 ## Examples
 
@@ -27,9 +27,9 @@ public OnGameModeInit()
 {
     new Float:param, Float:result;
     param = 0.5;
-    result = asin (param) * 180.0 / PI;
-    printf ("The arc sine of %f is %f degrees\n", param, result);
-    return 0;
+    result = asin(param);
+    printf("The arc sine of %f is %f degrees.", param, result);
+    return 1;
 }
 ```
 
@@ -38,3 +38,6 @@ public OnGameModeInit()
 - [floatsin](floatsin): Get the sine from a specific angle.
 - [floatcos](floatcos): Get the cosine from a specific angle.
 - [floattan](floattan): Get the tangent from a specific angle.
+- [acos](acos): Get the inversed value of a cosine in degrees.
+- [atan](atan): Get the inversed value of a tangent in degrees.
+- [atan2](atan2): Get the multi-valued inversed value of a tangent in degrees.

--- a/docs/scripting/functions/atan.md
+++ b/docs/scripting/functions/atan.md
@@ -1,6 +1,6 @@
 ---
 title: atan
-description: Get the inversed value of an arc tangent in radians.
+description: Get the inversed value of a tangent in degrees.
 tags: ["math"]
 ---
 
@@ -8,28 +8,28 @@ tags: ["math"]
 
 ## Description
 
-Get the inversed value of an arc tangent in radians.
+Get the inversed value of a tangent in degrees. In trigonometrics, arc tangent is the inverse operation of tangent. Notice that because of the sign ambiguity, the function cannot determine with certainty in which quadrant the angle falls only by its tangent value. See [atan2](atan2) for an alternative that takes a fractional argument instead.
 
-| Name        | Description                |
-| ----------- | -------------------------- |
-| Float:value | the input in arc tangents. |
+| Name        | Description                          |
+| ----------- | ------------------------------------ |
+| Float:value | value whose arc tangent is computed. |
 
 ## Returns
 
-The radiant of the angle in radians.
+The angle in degrees, in the interval [-90.0,+90.0].
 
 ## Examples
 
 ```c
-//This function returns radiants. Because most SA-MP functions use degrees, it is advised to convert them using the formula: result = atan (param) * 180 / PI
+//The arc tangent of 1.000000 is 45.000000 degrees.
 
 public OnGameModeInit()
 {
     new Float:param, Float:result;
     param = 1.0;
-    result = atan(param) * 180 / 3.14159265; //1 radian equals 180 degrees. 3.14... is used to define PI.
-    printf ("The arc tangent of %f is %f degrees\n", param, result );
-    return 0;
+    result = atan(param);
+    printf("The arc tangent of %f is %f degrees.", param, result);
+    return 1;
 }
 ```
 
@@ -38,3 +38,6 @@ public OnGameModeInit()
 - [floatsin](floatsin): Get the sine from a specific angle.
 - [floatcos](floatcos): Get the cosine from a specific angle.
 - [floattan](floattan): Get the tangent from a specific angle.
+- [asin](asin): Get the inversed value of a sine in degrees.
+- [acos](acos): Get the inversed value of a cosine in degrees.
+- [atan2](atan2): Get the multi-valued inversed value of a tangent in degrees.

--- a/docs/scripting/functions/atan2.md
+++ b/docs/scripting/functions/atan2.md
@@ -1,6 +1,6 @@
 ---
-title: atan2
-description: Get the inversed value of an arc tangent of y/x, expressed in radians.
+title: atan
+description: Get the multi-valued inversed value of a tangent in degrees.
 tags: ["math"]
 ---
 
@@ -8,24 +8,22 @@ tags: ["math"]
 
 :::warning
 
-Notice that the y-value is the first parameter and the x-value is the second parameter.
+Notice that the y-value is the first parameter and the x-value is the second parameter. This is because the mathematical notation is y/x (i.e. y divided by x) and the convention is to write the operands in the order of the operation that is performed on them.
 
 :::
 
 ## Description
 
-Get the inversed value of an arc tangent of y/x, expressed in radians.
+Get the multi-valued inversed value of a tangent in degrees. In trigonometrics, arc tangent is the inverse operation of tangent. To compute the value, the function takes into account the sign of both arguments in order to determine the quadrant.
 
 | Name    | Description                                            |
 | ------- | ------------------------------------------------------ |
-| Float:y | Value representing the proportion of the y-coordinate. |
-| Float:x | Value representing the proportion of the x-coordinate. |
+| Float:y | value representing the proportion of the y-coordinate. |
+| Float:x | value representing the proportion of the x-coordinate. |
 
 ## Returns
 
-Returns the principal value of the arc tangent of y/x, expressed in radians.
-
-To compute the value, the function takes into account the sign of both arguments in order to determine the quadrant.
+The angle in degrees, in the interval [-180.0,+180.0].
 
 ## Examples
 
@@ -37,9 +35,9 @@ public OnGameModeInit()
     new Float:x, Float:y, Float:result;
     x = -10.0;
     y = 10.0;
-    result = atan2 (y,x) * 180 / PI;
-    printf ("The arc tangent for (x=%f, y=%f) is %f degrees\n", x, y, result );
-    return 0;
+    result = atan2(y, x);
+    printf("The arc tangent for (x=%f, y=%f) is %f degrees.", x, y, result);
+    return 1;
 }
 ```
 
@@ -48,3 +46,6 @@ public OnGameModeInit()
 - [floatsin](floatsin): Get the sine from a specific angle.
 - [floatcos](floatcos): Get the cosine from a specific angle.
 - [floattan](floattan): Get the tangent from a specific angle.
+- [asin](asin): Get the inversed value of a sine in degrees.
+- [acos](acos): Get the inversed value of a cosine in degrees.
+- [atan](atan): Get the inversed value of a tangent in degrees.

--- a/docs/translations/bs/scripting/functions/acos.md
+++ b/docs/translations/bs/scripting/functions/acos.md
@@ -31,9 +31,9 @@ public OnGameModeInit()
 {
     new Float:param, Float:result;
     param = 0.5;
-    result = acos (param) * 180.0 / PI;
-    printf ("Glavni kosinus od %f je %f stepeni.\n", param, result);
-    return 0;
+    result = acos(param);
+    printf("Glavni kosinus od %f je %f stepeni.", param, result);
+    return 1;
 }
 ```
 

--- a/docs/translations/bs/scripting/functions/asin.md
+++ b/docs/translations/bs/scripting/functions/asin.md
@@ -31,9 +31,9 @@ public OnGameModeInit()
 {
     new Float:param, Float:result;
     param = 0.5;
-    result = asin (param) * 180.0 / PI;
-    printf ("Sinusni luk od %f je %f stepeni\n", param, result);
-    return 0;
+    result = asin(param);
+    printf("Sinusni luk od %f je %f stepeni.", param, result);
+    return 1;
 }
 ```
 

--- a/docs/translations/bs/scripting/functions/atan.md
+++ b/docs/translations/bs/scripting/functions/atan.md
@@ -25,15 +25,13 @@ Radijant ugla u radijanima.
 ## Primjeri
 
 ```c
-//Ova funkcija returna(vraća) radijane. Budući da većina SA-MP funkcija koristi stupnjeve, savjetuje se da ih konvertiraju koristeći formulu: rezultat = atan (param) * 180 / PI
-
 public OnGameModeInit()
 {
     new Float:param, Float:result;
     param = 1.0;
-    result = atan(param) * 180 / 3.14159265; //1 radian equals 180 degrees. 3.14... is used to define PI.
-    printf ("Tangent luka od %f je %f stepeni\n", param, result );
-    return 0;
+    result = atan(param);
+    printf("Tangent luka od %f je %f stepeni.", param, result);
+    return 1;
 }
 ```
 

--- a/docs/translations/bs/scripting/functions/atan2.md
+++ b/docs/translations/bs/scripting/functions/atan2.md
@@ -41,9 +41,9 @@ public OnGameModeInit()
     new Float:x, Float:y, Float:result;
     x = -10.0;
     y = 10.0;
-    result = atan2 (y,x) * 180 / PI;
-    printf ("Tangenta luka za (x=%f, y=%f) je %f stepeni\n", x, y, result );
-    return 0;
+    result = atan2(y,x);
+    printf("Tangenta luka za (x=%f, y=%f) je %f stepeni.", x, y, result);
+    return 1;
 }
 ```
 

--- a/docs/translations/pl/scripting/functions/acos.md
+++ b/docs/translations/pl/scripting/functions/acos.md
@@ -27,9 +27,9 @@ public OnGameModeInit()
 {
     new Float:param, Float:result;
     param = 0.5;
-    result = acos (param) * 180.0 / PI;
-    printf ("Arcus cosinus dla %f wynosi %f stopni.\n", param, result);
-    return 0;
+    result = acos(param);
+    printf("Arcus cosinus dla %f wynosi %f stopni.", param, result);
+    return 1;
 }
 ```
 

--- a/docs/translations/pl/scripting/functions/asin.md
+++ b/docs/translations/pl/scripting/functions/asin.md
@@ -27,9 +27,9 @@ public OnGameModeInit()
 {
     new Float:param, Float:result;
     param = 0.5;
-    result = asin (param) * 180.0 / PI;
-    printf ("Arcus sinus dla %f wynosi %f stopni\n", param, result);
-    return 0;
+    result = asin(param);
+    printf("Arcus sinus dla %f wynosi %f stopni.", param, result);
+    return 1;
 }
 ```
 

--- a/docs/translations/pl/scripting/functions/atan.md
+++ b/docs/translations/pl/scripting/functions/atan.md
@@ -21,15 +21,13 @@ Odwrócona wartość arcus tangensa w radianach.
 ## Examples
 
 ```c
-//Ta funkcja zwraca radiany. Większość funkcji SA-MP używa stopni, dlatego zaleca się skonwertować je używając wzoru: result = atan (param) * 180 / PI
-
 public OnGameModeInit()
 {
     new Float:param, Float:result;
     param = 1.0;
-    result = atan(param) * 180 / 3.14159265; //1 radian to 180 stopni. 3.14... to liczba Pi.
-    printf ("Arcus tangens dla %f wynosi %f stopni\n", param, result );
-    return 0;
+    result = atan(param);
+    printf("Arcus tangens dla %f wynosi %f stopni.", param, result);
+    return 1;
 }
 ```
 

--- a/docs/translations/pl/scripting/functions/atan2.md
+++ b/docs/translations/pl/scripting/functions/atan2.md
@@ -37,9 +37,9 @@ public OnGameModeInit()
     new Float:x, Float:y, Float:result;
     x = -10.0;
     y = 10.0;
-    result = atan2 (y,x) * 180 / PI;
-    printf ("Arcus tangens dlar (x=%f, y=%f) wynosi %f stopni\n", x, y, result );
-    return 0;
+    result = atan2(y,x);
+    printf("Arcus tangens dlar (x=%f, y=%f) wynosi %f stopni.", x, y, result);
+    return 1;
 }
 ```
 

--- a/docs/translations/ro/scripting/functions/acos.md
+++ b/docs/translations/ro/scripting/functions/acos.md
@@ -27,9 +27,9 @@ public OnGameModeInit()
 {
     new Float:param, Float:result;
     param = 0.5;
-    result = acos (param) * 180.0 / PI;
-    printf ("The arc cosine of %f is %f degrees.\n", param, result);
-    return 0;
+    result = acos(param);
+    printf("The arc cosine of %f is %f degrees.", param, result);
+    return 1;
 }
 ```
 

--- a/docs/translations/ru/scripting/functions/acos.md
+++ b/docs/translations/ru/scripting/functions/acos.md
@@ -1,22 +1,22 @@
 ---
 title: acos
-description: .
-tags: []
+description: Get the inversed value of a cosine in degrees.
+tags: ["math"]
 ---
 
 <LowercaseNote />
 
 ## Description
 
-Get the inversed value of an arc cosine in radians.
+Get the inversed value of a cosine in degrees. In trigonometrics, arc cosine is the inverse operation of cosine.
 
-| Name        | Description              |
-| ----------- | ------------------------ |
-| Float:value | the input in arc cosine. |
+| Name        | Description                                                  |
+| ----------- | ------------------------------------------------------------ |
+| Float:value | value whose arc cosine is computed, in the interval [-1,+1]. |
 
 ## Returns
 
-Principal arc cosine of x, in the interval [0, pi] radians. One radian is equivalent to 180/PI degrees.
+The angle in degrees, in the interval [0.0,180.0].
 
 ## Examples
 
@@ -27,14 +27,17 @@ public OnGameModeInit()
 {
     new Float:param, Float:result;
     param = 0.5;
-    result = acos (param) * 180.0 / PI;
-    printf ("The arc cosine of %f is %f degrees.\n", param, result);
-    return 0;
+    result = acos(param);
+    printf("The arc cosine of %f is %f degrees.", param, result);
+    return 1;
 }
 ```
 
 ## Related Functions
 
-- [floatsin](floatsin.md): Get the sine from a specific angle.
-- [floatcos](floatcos.md): Get the cosine from a specific angle.
-- [floattan](floattan.md): Get the tangent from a specific angle.
+- [floatsin](floatsin): Get the sine from a specific angle.
+- [floatcos](floatcos): Get the cosine from a specific angle.
+- [floattan](floattan): Get the tangent from a specific angle.
+- [asin](asin): Get the inversed value of a sine in degrees.
+- [atan](atan): Get the inversed value of a tangent in degrees.
+- [atan2](atan2): Get the multi-valued inversed value of a tangent in degrees.

--- a/docs/translations/th/scripting/functions/atan.md
+++ b/docs/translations/th/scripting/functions/atan.md
@@ -1,44 +1,43 @@
 ---
 title: atan
-description: Get the inversed value of an arc tangent in radians.
-tags: []
+description: Get the inversed value of a tangent in degrees.
+tags: ["math"]
 ---
 
-:::warning
-
-This function starts with lowercase letter.
-
-:::
+<LowercaseNote />
 
 ## คำอธิบาย
 
-Get the inversed value of an arc tangent in radians.
+Get the inversed value of a tangent in degrees. In trigonometrics, arc tangent is the inverse operation of tangent. Notice that because of the sign ambiguity, the function cannot determine with certainty in which quadrant the angle falls only by its tangent value. See [atan2](atan2) for an alternative that takes a fractional argument instead.
 
-| Name        | Description                |
-| ----------- | -------------------------- |
-| Float:value | the input in arc tangents. |
+| Name        | Description                          |
+| ----------- | ------------------------------------ |
+| Float:value | value whose arc tangent is computed. |
 
 ## ส่งคืน
 
-The radiant of the angle in radians.
+The angle in degrees, in the interval [-90.0,+90.0].
 
 ## ตัวอย่าง
 
 ```c
-//This function returns radiants. Because most SA-MP functions use degrees, it is advised to convert them using the formula: result = atan (param) * 180 / PI
+//The arc tangent of 1.000000 is 45.000000 degrees.
 
 public OnGameModeInit()
 {
     new Float:param, Float:result;
     param = 1.0;
-    result = atan(param) * 180 / 3.14159265; //1 radian equals 180 degrees. 3.14... is used to define PI.
-    printf ("The arc tangent of %f is %f degrees\n", param, result );
-    return 0;
+    result = atan(param);
+    printf("The arc tangent of %f is %f degrees.", param, result);
+    return 1;
 }
 ```
 
 ## ฟังก์ชั่นที่เกี่ยวข้องกัน
 
-- [floatsin](../../scripting/functions/floatsin.md): Get the sine from a specific angle.
-- [floatcos](../../scripting/functions/floatcos.md): Get the cosine from a specific angle.
-- [floattan](../../scripting/functions/floattan.md): Get the tangent from a specific angle.
+- [floatsin](floatsin): Get the sine from a specific angle.
+- [floatcos](floatcos): Get the cosine from a specific angle.
+- [floattan](floattan): Get the tangent from a specific angle.
+- [asin](asin): Get the inversed value of a sine in degrees.
+- [acos](acos): Get the inversed value of a cosine in degrees.
+- [atan2](atan2): Get the multi-valued inversed value of a tangent in degrees.

--- a/docs/translations/tr/scripting/functions/acos.md
+++ b/docs/translations/tr/scripting/functions/acos.md
@@ -31,9 +31,9 @@ public OnGameModeInit()
 {
     new Float:param, Float:result;
     param = 0.5;
-    result = acos (param) * 180.0 / PI;
-    printf ("%f yay kosinüsü %f derece.\n", param, result);
-    return 0;
+    result = acos(param);
+    printf("%f yay kosinüsü %f derece.", param, result);
+    return 1;
 }
 ```
 


### PR DESCRIPTION
Documentation for these pages were wrong, mostly because these functions return degrees in sa-mp, not radians:
- asin
- acos
- atan
- atan2

Also fixed the examples for other languages.