### PR TITLE
Changed sampctl link

### DIFF
--- a/docs/awesome.md
+++ b/docs/awesome.md
@@ -6,7 +6,7 @@ description: A curated list of useful tools, libraries, gamemodes, filterscripts
 ## Tools
 
 - **[Community Compiler](https://github.com/pawn-lang/compiler/)** - A vastly updated version of the compiler, with many fixes and enhancements.
-- **[sampctl](http://sampctl.com/)** - Package manager for installing libraries and running your server.
+- **[sampctl](https://github.com/Southclaws/sampctl/)** - Package manager for installing libraries and running your server.
 - **[Plugin Runner](https://github.com/Zeex/samp-plugin-runner/)** - Tool to run a lightweight version of the server directly from command-line (no server.cfg required) for testing plugins.
 - **[Pawn Syntax - Sublime](https://packagecontrol.io/packages/Pawn%20syntax/)** - Pawn autocompletes for Sublime Text.
 - **[Pawn Syntax - Visual Marketplace](https://marketplace.visualstudio.com/items?itemName=southclaws.vscode-pawn/)** - Pawn autocompletes for Visual Studio Code.


### PR DESCRIPTION
Current link points to a random website that isn't owned anymore by southclaws so its full of ads.
This redirects to the github page for sampctl