### PR TITLE
Changed a spelling error from 'GetPlayerCameraAspectRation' to 'GetPlayerCameraAspectRatio'

### DIFF
--- a/docs/scripting/functions/GetPlayerCameraPos.md
+++ b/docs/scripting/functions/GetPlayerCameraPos.md
@@ -48,6 +48,6 @@ Player's camera positions are only updated once a second, unless aiming.It is re
 
 - [SetPlayerCameraPos](SetPlayerCameraPos): Set a player's camera position.
 - [GetPlayerCameraZoom](GetPlayerCameraZoom): Get the zoom level of a player's camera.
-- [GetPlayerCameraAspectRatio](GetPlayerCameraAspectRation): Get the aspect ratio of a player's camera.
+- [GetPlayerCameraAspectRatio](GetPlayerCameraAspectRatio): Get the aspect ratio of a player's camera.
 - [GetPlayerCameraMode](GetplayerCameraMode): Get a player's camera mode.
 - [GetPlayerCameraFrontVector](GetPlayerCameraFrontVector): Get the player's camera front vector


### PR DESCRIPTION
A small spelling error in the function URL which was redirecting it to an error page saying 'GetPlayerCameraAspectRation' was not found.