### PR TITLE
'db_close' misspell fix

### DIFF
--- a/docs/scripting/functions/GetPlayerCameraPos.md
+++ b/docs/scripting/functions/GetPlayerCameraPos.md
@@ -48,6 +48,6 @@ Player's camera positions are only updated once a second, unless aiming.It is re
 
 - [SetPlayerCameraPos](SetPlayerCameraPos): Set a player's camera position.
 - [GetPlayerCameraZoom](GetPlayerCameraZoom): Get the zoom level of a player's camera.
-- [GetPlayerCameraAspectRatio](GetPlayerCameraAspectRation): Get the aspect ratio of a player's camera.
+- [GetPlayerCameraAspectRatio](GetPlayerCameraAspectRatio): Get the aspect ratio of a player's camera.
 - [GetPlayerCameraMode](GetplayerCameraMode): Get a player's camera mode.
 - [GetPlayerCameraFrontVector](GetPlayerCameraFrontVector): Get the player's camera front vector

--- a/docs/scripting/functions/db_debug_openfiles.md
+++ b/docs/scripting/functions/db_debug_openfiles.md
@@ -18,7 +18,7 @@ The function gets the number of open database connections for debugging purposes
 ## Related Functions
 
 - [db_open](db_open): Open a connection to an SQLite database
-- [db_close](b_close): Close the connection to an SQLite database
+- [db_close](db_close): Close the connection to an SQLite database
 - [db_query](db_query): Query an SQLite database
 - [db_free_result](db_free_result): Free result memory from a db_query
 - [db_num_rows](db_num_rows): Get the number of rows in a result

--- a/docs/scripting/functions/db_debug_openresults.md
+++ b/docs/scripting/functions/db_debug_openresults.md
@@ -18,7 +18,7 @@ The function gets the number of open database results.
 ## Related Functions
 
 - [db_open](db_open): Open a connection to an SQLite database
-- [db_close](b_close): Close the connection to an SQLite database
+- [db_close](db_close): Close the connection to an SQLite database
 - [db_query](db_query): Query an SQLite database
 - [db_free_result](db_free_result): Free result memory from a db_query
 - [db_num_rows](db_num_rows): Get the number of rows in a result

--- a/docs/scripting/functions/db_field_name.md
+++ b/docs/scripting/functions/db_field_name.md
@@ -96,7 +96,7 @@ Using an invalid handle other than zero will crash your server! Get a valid data
 ## Related Functions
 
 - [db_open](db_open): Open a connection to an SQLite database
-- [db_close](b_close): Close the connection to an SQLite database
+- [db_close](db_close): Close the connection to an SQLite database
 - [db_query](db_query): Query an SQLite database
 - [db_free_result](db_free_result): Free result memory from a db_query
 - [db_num_rows](db_num_rows): Get the number of rows in a result

--- a/docs/scripting/functions/db_free_result.md
+++ b/docs/scripting/functions/db_free_result.md
@@ -100,7 +100,7 @@ Using an invalid handle other than zero will crash your server! Get a valid data
 ## Related Functions
 
 - [db_open](db_open): Open a connection to an SQLite database
-- [db_close](b_close): Close the connection to an SQLite database
+- [db_close](db_close): Close the connection to an SQLite database
 - [db_query](db_query): Query an SQLite database
 - [db_num_rows](db_num_rows): Get the number of rows in a result
 - [db_next_row](db_next_row): Move to the next row

--- a/docs/scripting/functions/db_get_field.md
+++ b/docs/scripting/functions/db_get_field.md
@@ -158,7 +158,7 @@ Using an invalid handle other than zero will crash your server! Get a valid data
 ## Related Functions
 
 - [db_open](db_open): Open a connection to an SQLite database
-- [db_close](b_close): Close the connection to an SQLite database
+- [db_close](db_close): Close the connection to an SQLite database
 - [db_query](db_query): Query an SQLite database
 - [db_free_result](db_free_result): Free result memory from a db_query
 - [db_num_rows](db_num_rows): Get the number of rows in a result

--- a/docs/scripting/functions/db_get_field_assoc.md
+++ b/docs/scripting/functions/db_get_field_assoc.md
@@ -118,7 +118,7 @@ Using an invalid handle other than zero will crash your server! Get a valid data
 ## Related Functions
 
 - [db_open](db_open): Open a connection to an SQLite database
-- [db_close](b_close): Close the connection to an SQLite database
+- [db_close](db_close): Close the connection to an SQLite database
 - [db_query](db_query): Query an SQLite database
 - [db_free_result](db_free_result): Free result memory from a db_query
 - [db_num_rows](db_num_rows): Get the number of rows in a result

--- a/docs/scripting/functions/db_get_field_assoc_float.md
+++ b/docs/scripting/functions/db_get_field_assoc_float.md
@@ -119,7 +119,7 @@ Using an invalid handle other than zero will crash your server! Get a valid data
 ## Related Functions
 
 - [db_open](db_open): Open a connection to an SQLite database
-- [db_close](b_close): Close the connection to an SQLite database
+- [db_close](db_close): Close the connection to an SQLite database
 - [db_query](db_query): Query an SQLite database
 - [db_free_result](db_free_result): Free result memory from a db_query
 - [db_num_rows](db_num_rows): Get the number of rows in a result

--- a/docs/scripting/functions/db_get_field_assoc_int.md
+++ b/docs/scripting/functions/db_get_field_assoc_int.md
@@ -119,7 +119,7 @@ Using an invalid handle other than zero will crash your server! Get a valid data
 ## Related Functions
 
 - [db_open](db_open): Open a connection to an SQLite database
-- [db_close](b_close): Close the connection to an SQLite database
+- [db_close](db_close): Close the connection to an SQLite database
 - [db_query](db_query): Query an SQLite database
 - [db_free_result](db_free_result): Free result memory from a db_query
 - [db_num_rows](db_num_rows): Get the number of rows in a result

--- a/docs/scripting/functions/db_get_field_float.md
+++ b/docs/scripting/functions/db_get_field_float.md
@@ -159,7 +159,7 @@ Using an invalid handle other than zero will crash your server! Get a valid data
 ## Related Functions
 
 - [db_open](db_open): Open a connection to an SQLite database
-- [db_close](b_close): Close the connection to an SQLite database
+- [db_close](db_close): Close the connection to an SQLite database
 - [db_query](db_query): Query an SQLite database
 - [db_free_result](db_free_result): Free result memory from a db_query
 - [db_num_rows](db_num_rows): Get the number of rows in a result

--- a/docs/scripting/functions/db_get_field_int.md
+++ b/docs/scripting/functions/db_get_field_int.md
@@ -159,7 +159,7 @@ Using an invalid handle other than zero will crash your server! Get a valid data
 ## Related Functions
 
 - [db_open](db_open): Open a connection to an SQLite database
-- [db_close](b_close): Close the connection to an SQLite database
+- [db_close](db_close): Close the connection to an SQLite database
 - [db_query](db_query): Query an SQLite database
 - [db_free_result](db_free_result): Free result memory from a db_query
 - [db_num_rows](db_num_rows): Get the number of rows in a result

--- a/docs/scripting/functions/db_get_mem_handle.md
+++ b/docs/scripting/functions/db_get_mem_handle.md
@@ -79,7 +79,7 @@ Using an invalid handle other than zero will crash your server! Get a valid data
 ## Related Functions
 
 - [db_open](db_open): Open a connection to an SQLite database
-- [db_close](b_close): Close the connection to an SQLite database
+- [db_close](db_close): Close the connection to an SQLite database
 - [db_query](db_query): Query an SQLite database
 - [db_free_result](db_free_result): Free result memory from a db_query
 - [db_num_rows](db_num_rows): Get the number of rows in a result

--- a/docs/scripting/functions/db_get_result_mem_handle.md
+++ b/docs/scripting/functions/db_get_result_mem_handle.md
@@ -84,7 +84,7 @@ Using an invalid handle other than zero will crash your server! Get a valid data
 ## Related Functions
 
 - [db_open](db_open): Open a connection to an SQLite database
-- [db_close](b_close): Close the connection to an SQLite database
+- [db_close](db_close): Close the connection to an SQLite database
 - [db_query](db_query): Query an SQLite database
 - [db_free_result](db_free_result): Free result memory from a db_query
 - [db_num_rows](db_num_rows): Get the number of rows in a result

--- a/docs/scripting/functions/db_next_row.md
+++ b/docs/scripting/functions/db_next_row.md
@@ -115,7 +115,7 @@ Using an invalid handle other than zero will crash your server! Get a valid data
 ## Related Functions
 
 - [db_open](db_open): Open a connection to an SQLite database
-- [db_close](b_close): Close the connection to an SQLite database
+- [db_close](db_close): Close the connection to an SQLite database
 - [db_query](db_query): Query an SQLite database
 - [db_free_result](db_free_result): Free result memory from a db_query
 - [db_num_rows](db_num_rows): Get the number of rows in a result

--- a/docs/scripting/functions/db_num_fields.md
+++ b/docs/scripting/functions/db_num_fields.md
@@ -158,7 +158,7 @@ Using an invalid handle other than zero will crash your server! Get a valid data
 ## Related Functions
 
 - [db_open](db_open): Open a connection to an SQLite database
-- [db_close](b_close): Close the connection to an SQLite database
+- [db_close](db_close): Close the connection to an SQLite database
 - [db_query](db_query): Query an SQLite database
 - [db_free_result](db_free_result): Free result memory from a db_query
 - [db_num_rows](db_num_rows): Get the number of rows in a result

--- a/docs/scripting/functions/db_num_rows.md
+++ b/docs/scripting/functions/db_num_rows.md
@@ -115,7 +115,7 @@ Using an invalid handle other than zero will crash your server! Get a valid data
 ## Related Functions
 
 - [db_open](db_open): Open a connection to an SQLite database
-- [db_close](b_close): Close the connection to an SQLite database
+- [db_close](db_close): Close the connection to an SQLite database
 - [db_query](db_query): Query an SQLite database
 - [db_free_result](db_free_result): Free result memory from a db_query
 - [db_next_row](db_next_row): Move to the next row

--- a/docs/scripting/functions/db_open.md
+++ b/docs/scripting/functions/db_open.md
@@ -75,7 +75,7 @@ It will create a new SQLite database file, if there is no SQLite database file w
 
 ## Related Functions
 
-- [db_close](b_close): Close the connection to an SQLite database
+- [db_close](db_close): Close the connection to an SQLite database
 - [db_query](db_query): Query an SQLite database
 - [db_free_result](db_free_result): Free result memory from a db_query
 - [db_num_rows](db_num_rows): Get the number of rows in a result

--- a/docs/scripting/functions/db_query.md
+++ b/docs/scripting/functions/db_query.md
@@ -101,7 +101,7 @@ Always free results by using [db_free_result](db_free_result)!
 ## Related Functions
 
 - [db_open](db_open): Open a connection to an SQLite database
-- [db_close](b_close): Close the connection to an SQLite database
+- [db_close](db_close): Close the connection to an SQLite database
 - [db_free_result](db_free_result): Free result memory from a db_query
 - [db_num_rows](db_num_rows): Get the number of rows in a result
 - [db_next_row](db_next_row): Move to the next row


### PR DESCRIPTION
'db_close' was misspelled as 'b_close' in most of the files hence it was redirecting to an error page. This branch includes the fix for the 17 files.

File spelled incorrect (b_close.md) in file (db_debug_openfiles.md)
File spelled incorrect (b_close.md) in file (db_debug_openresults.md)
File spelled incorrect (b_close.md) in file (db_field_name.md)
File spelled incorrect (b_close.md) in file (db_free_result.md)
File spelled incorrect (b_close.md) in file (db_get_field.md)
File spelled incorrect (b_close.md) in file (db_get_field_assoc.md)
File spelled incorrect (b_close.md) in file (db_get_field_assoc_float.md)
File spelled incorrect (b_close.md) in file (db_get_field_assoc_int.md)
File spelled incorrect (b_close.md) in file (db_get_field_float.md)
File spelled incorrect (b_close.md) in file (db_get_field_int.md)
File spelled incorrect (b_close.md) in file (db_get_mem_handle.md)
File spelled incorrect (b_close.md) in file (db_get_result_mem_handle.md)
File spelled incorrect (b_close.md) in file (db_next_row.md)
File spelled incorrect (b_close.md) in file (db_num_fields.md)
File spelled incorrect (b_close.md) in file (db_num_rows.md)
File spelled incorrect (b_close.md) in file (db_open.md)
File spelled incorrect (b_close.md) in file (db_query.md)

