### PR TITLE
Remove the backslash in the description of ResetPlayerMoney

### DIFF
--- a/docs/scripting/functions/ResetPlayerMoney.md
+++ b/docs/scripting/functions/ResetPlayerMoney.md
@@ -6,7 +6,7 @@ tags: ["player"]
 
 ## Description
 
-Reset a player's money to \$0.
+Reset a player's money to $0.
 
 | Name     | Description                                 |
 | -------- | ------------------------------------------- |


### PR DESCRIPTION
Why is it there? Is it a mistake or I'm missing something?

![image](https://user-images.githubusercontent.com/4629328/125171595-b5cb4c00-e1bd-11eb-93ca-1f84c21a2774.png)
