### PR TITLE
clean up oauth code by moving DB operations to user resource

### DIFF
--- a/server/src/authentication/auth.go
+++ b/server/src/authentication/auth.go
@@ -100,3 +100,19 @@ func IsRequestAdmin(r *http.Request) bool {
 	}
 	return info.Cookie.Admin
 }
+
+func (s *State) GetOrCreateFromContext(ctx context.Context, email, authMethod, username string) (*user.User, error) {
+	if existing, ok := GetAuthenticationInfoFromContext(ctx); ok && existing.Authenticated {
+		u, err := s.users.GetUser(ctx, existing.Cookie.UserID, false)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to find user account")
+		}
+		return u, nil
+	} else {
+		u, err := s.users.CreateUser(ctx, email, user.AuthMethod(authMethod), username)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create user account")
+		}
+		return u, nil
+	}
+}

--- a/server/src/resources/user/db.go
+++ b/server/src/resources/user/db.go
@@ -16,6 +16,45 @@ func New(db *db.PrismaClient) Repository {
 	return &DB{db}
 }
 
+func (d *DB) CreateUser(ctx context.Context, email string, authMethod AuthMethod, username string) (*User, error) {
+	u, err := d.db.User.CreateOne(
+		db.User.Email.Set(email),
+		db.User.AuthMethod.Set(db.AuthMethod(authMethod)),
+		db.User.Name.Set(username),
+	).Exec(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return FromModel(u, false), nil
+}
+
+func (d *DB) LinkGitHub(ctx context.Context, userID, githubAccountID, githubUsername, githubEmail string) error {
+	_, err := d.db.GitHub.CreateOne(
+		db.GitHub.User.Link(db.User.ID.Equals(userID)),
+		db.GitHub.AccountID.Set(githubAccountID),
+		db.GitHub.Username.Set(githubUsername),
+		db.GitHub.Email.Set(githubEmail),
+	).Exec(ctx)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *DB) LinkDiscord(ctx context.Context, userID, discordAccountID, discordUsername, discordEmail string) error {
+	_, err := d.db.Discord.CreateOne(
+		db.Discord.User.Link(db.User.ID.Equals(userID)),
+		db.Discord.AccountID.Set(discordAccountID),
+		db.Discord.Username.Set(discordUsername),
+		db.Discord.Email.Set(discordEmail),
+	).Exec(ctx)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (d *DB) GetUser(ctx context.Context, userId string, public bool) (*User, error) {
 	user, err := d.db.User.
 		FindUnique(db.User.ID.Equals(userId)).
@@ -23,6 +62,24 @@ func (d *DB) GetUser(ctx context.Context, userId string, public bool) (*User, er
 			db.User.Github.Fetch(),
 			db.User.Discord.Fetch(),
 			db.User.Servers.Fetch(),
+		).
+		Exec(ctx)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return FromModel(user, public), nil
+}
+
+func (d *DB) GetUserByEmail(ctx context.Context, email string, public bool) (*User, error) {
+	user, err := d.db.User.
+		FindUnique(db.User.ID.Equals(email)).
+		With(
+			db.User.Github.Fetch(),
+			db.User.Discord.Fetch(),
 		).
 		Exec(ctx)
 	if err != nil {

--- a/server/src/resources/user/model.go
+++ b/server/src/resources/user/model.go
@@ -6,6 +6,8 @@ import (
 	"github.com/openmultiplayer/web/server/src/db"
 )
 
+type AuthMethod string
+
 type User struct {
 	ID         string     `json:"id"`
 	Email      string     `json:"email"`

--- a/server/src/resources/user/repository.go
+++ b/server/src/resources/user/repository.go
@@ -5,7 +5,12 @@ import (
 )
 
 type Repository interface {
+	CreateUser(ctx context.Context, email string, authMethod AuthMethod, username string) (*User, error)
+	LinkGitHub(ctx context.Context, userID, githubAccountID, githubUsername, githubEmail string) error
+	LinkDiscord(ctx context.Context, userID, discordAccountID, discordUsername, discordEmail string) error
+
 	GetUser(ctx context.Context, userId string, public bool) (*User, error)
+	GetUserByEmail(ctx context.Context, email string, public bool) (*User, error)
 	GetUsers(ctx context.Context, sort string, max, skip int, public bool) ([]User, error)
 	UpdateUser(ctx context.Context, userId string, email, name *string) (*User, error)
 	SetAdmin(ctx context.Context, userId string, status bool) (bool, error)


### PR DESCRIPTION
Also now uses the email on the account to associate profiles instead of the email specific to the integration - this will make account migration easier