### PR TITLE
Split out forum endpoints

### DIFF
--- a/frontend/src/components/forum/ThreadListView.tsx
+++ b/frontend/src/components/forum/ThreadListView.tsx
@@ -50,7 +50,7 @@ const ThreadListView: FC<Props> = ({
 
   const isAdmin = useIsAdmin();
   const { data, error } = useSWR<Post[], APIError>(
-    "/forum?" +
+    "/forum/threads?" +
       new URLSearchParams([
         ["category", category],
         ["query", initialText],

--- a/frontend/src/components/forum/hooks.ts
+++ b/frontend/src/components/forum/hooks.ts
@@ -35,7 +35,7 @@ export const useCreateThread = (): CreateThreadFn => {
       }
 
       try {
-        const post = await apiSSP<Post>("/forum", {
+        const post = await apiSSP<Post>("/forum/threads", {
           method: "POST",
           body: JSON.stringify(data),
         });

--- a/frontend/src/components/forum/hooks.ts
+++ b/frontend/src/components/forum/hooks.ts
@@ -69,7 +69,7 @@ export const useCreatePost = (
       }
 
       try {
-        await apiSSP<Post>(`/forum/${id}`, {
+        await apiSSP<Post>(`/forum/posts/${id}`, {
           method: "POST",
           body: JSON.stringify({ ...data, replyTo: replyTo?.id ?? null }),
           schema: PostSchema,
@@ -97,7 +97,7 @@ export const useDeletePost = (): DeleteFn => {
     async (id: string) => {
       nProgress.start();
       try {
-        await apiSSP<Post>(`/forum/${id}`, { method: "DELETE" });
+        await apiSSP<Post>(`/forum/posts/${id}`, { method: "DELETE" });
         toast({
           title: "Post deleted!",
           status: "success",
@@ -122,7 +122,7 @@ export const useEditPost = (): EditFn => {
     async (data: PostPayload) => {
       nProgress.start();
       try {
-        await apiSSP<Post>(`/forum/${data.id}`, {
+        await apiSSP<Post>(`/forum/posts/${data.id}`, {
           method: "PATCH",
           body: JSON.stringify(data),
         });

--- a/frontend/src/pages/discussion/[slug].tsx
+++ b/frontend/src/pages/discussion/[slug].tsx
@@ -53,7 +53,7 @@ export async function getServerSideProps(
   }
 
   try {
-    const posts = await apiSSP<Post[]>(`/forum/${slug}`, {
+    const posts = await apiSSP<Post[]>(`/forum/posts/${slug}`, {
       ctx,
       schema: PostSchema.array(),
     });

--- a/server/src/api/forum/api.go
+++ b/server/src/api/forum/api.go
@@ -5,14 +5,13 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/openmultiplayer/web/server/src/api/forum/categories"
+	"github.com/openmultiplayer/web/server/src/api/forum/posts"
 	"github.com/openmultiplayer/web/server/src/authentication"
-	"github.com/openmultiplayer/web/server/src/resources/forum/post"
 	"github.com/openmultiplayer/web/server/src/resources/forum/tag"
 	"github.com/openmultiplayer/web/server/src/resources/forum/thread"
 )
 
 type service struct {
-	posts   post.Repository
 	threads thread.Repository
 	tags    tag.Repository
 }
@@ -20,13 +19,13 @@ type service struct {
 func Build() fx.Option {
 	return fx.Options(
 		categories.Build(),
+		posts.Build(),
 
 		fx.Provide(func(
-			posts post.Repository,
 			threads thread.Repository,
 			tags tag.Repository,
 		) *service {
-			return &service{posts, threads, tags}
+			return &service{threads, tags}
 		}),
 		fx.Invoke(func(
 			r chi.Router,
@@ -40,23 +39,8 @@ func Build() fx.Option {
 				Get("/", s.list)
 
 			rtr.
-				Get("/{slug}", s.get)
-
-			rtr.
 				With(authentication.MustBeAuthenticated /*ratelimiter.WithRateLimit(5)*/).
 				Post("/", s.postThread)
-
-			rtr.
-				With(authentication.MustBeAuthenticated /*ratelimiter.WithRateLimit(20)*/).
-				Post("/{id}", s.postPost)
-
-			rtr.
-				With(authentication.MustBeAuthenticated /*ratelimiter.WithRateLimit(20)*/).
-				Patch("/{id}", s.patch)
-
-			rtr.
-				With(authentication.MustBeAuthenticated /*ratelimiter.WithRateLimit(20)*/).
-				Delete("/{id}", s.delete)
 
 			rtr.
 				Get("/tags", s.getTags)

--- a/server/src/api/forum/api.go
+++ b/server/src/api/forum/api.go
@@ -1,43 +1,19 @@
 package forum
 
 import (
-	"github.com/go-chi/chi"
 	"go.uber.org/fx"
 
 	"github.com/openmultiplayer/web/server/src/api/forum/categories"
 	"github.com/openmultiplayer/web/server/src/api/forum/posts"
+	"github.com/openmultiplayer/web/server/src/api/forum/tags"
 	"github.com/openmultiplayer/web/server/src/api/forum/threads"
-	"github.com/openmultiplayer/web/server/src/resources/forum/tag"
-	"github.com/openmultiplayer/web/server/src/resources/forum/thread"
 )
-
-type service struct {
-	threads thread.Repository
-	tags    tag.Repository
-}
 
 func Build() fx.Option {
 	return fx.Options(
 		categories.Build(),
 		posts.Build(),
 		threads.Build(),
-
-		fx.Provide(func(
-			threads thread.Repository,
-			tags tag.Repository,
-		) *service {
-			return &service{threads, tags}
-		}),
-		fx.Invoke(func(
-			r chi.Router,
-			s *service,
-
-		) {
-			rtr := chi.NewRouter()
-			r.Mount("/forum", rtr)
-
-			rtr.
-				Get("/tags", s.getTags)
-		}),
+		tags.Build(),
 	)
 }

--- a/server/src/api/forum/api.go
+++ b/server/src/api/forum/api.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/openmultiplayer/web/server/src/api/forum/categories"
 	"github.com/openmultiplayer/web/server/src/api/forum/posts"
-	"github.com/openmultiplayer/web/server/src/authentication"
+	"github.com/openmultiplayer/web/server/src/api/forum/threads"
 	"github.com/openmultiplayer/web/server/src/resources/forum/tag"
 	"github.com/openmultiplayer/web/server/src/resources/forum/thread"
 )
@@ -20,6 +20,7 @@ func Build() fx.Option {
 	return fx.Options(
 		categories.Build(),
 		posts.Build(),
+		threads.Build(),
 
 		fx.Provide(func(
 			threads thread.Repository,
@@ -34,13 +35,6 @@ func Build() fx.Option {
 		) {
 			rtr := chi.NewRouter()
 			r.Mount("/forum", rtr)
-
-			rtr.
-				Get("/", s.list)
-
-			rtr.
-				With(authentication.MustBeAuthenticated /*ratelimiter.WithRateLimit(5)*/).
-				Post("/", s.postThread)
 
 			rtr.
 				Get("/tags", s.getTags)

--- a/server/src/api/forum/posts/api.go
+++ b/server/src/api/forum/posts/api.go
@@ -1,0 +1,43 @@
+package posts
+
+import (
+	"github.com/go-chi/chi"
+	"go.uber.org/fx"
+
+	"github.com/openmultiplayer/web/server/src/authentication"
+	"github.com/openmultiplayer/web/server/src/resources/forum/post"
+)
+
+type service struct {
+	as   *authentication.State
+	repo post.Repository
+}
+
+func Build() fx.Option {
+	return fx.Options(
+		fx.Provide(func(as *authentication.State, repo post.Repository) *service { return &service{as, repo} }),
+		fx.Invoke(func(
+			r chi.Router,
+			s *service,
+
+		) {
+			rtr := chi.NewRouter()
+			r.Mount("/forum/posts", rtr)
+
+			rtr.
+				Get("/{slug}", s.get)
+
+			rtr.
+				With(authentication.MustBeAuthenticated /*ratelimiter.WithRateLimit(20)*/).
+				Post("/{id}", s.post)
+
+			rtr.
+				With(authentication.MustBeAuthenticated /*ratelimiter.WithRateLimit(20)*/).
+				Patch("/{id}", s.patch)
+
+			rtr.
+				With(authentication.MustBeAuthenticated /*ratelimiter.WithRateLimit(20)*/).
+				Delete("/{id}", s.delete)
+		}),
+	)
+}

--- a/server/src/api/forum/posts/h_delete.go
+++ b/server/src/api/forum/posts/h_delete.go
@@ -1,4 +1,4 @@
-package forum
+package posts
 
 import (
 	"encoding/json"
@@ -9,27 +9,16 @@ import (
 	"github.com/openmultiplayer/web/server/src/web"
 )
 
-type patchBody struct {
-	Title string `json:"title" valid:"stringlength(1|64)"`
-	Body  string `json:"body"  valid:"stringlength(1|65535)"`
-}
-
-func (s *service) patch(w http.ResponseWriter, r *http.Request) {
+func (s *service) delete(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	info, ok := authentication.GetAuthenticationInfo(w, r)
 	if !ok {
 		return
 	}
 
-	var b patchBody
-	if !web.ParseBody(w, r, &b) {
-		return
-	}
-
-	post, err := s.posts.EditPost(r.Context(), info.Cookie.UserID, id, &b.Title, &b.Body)
+	post, err := s.repo.DeletePost(r.Context(), info.Cookie.UserID, id, info.Cookie.Admin)
 	if err != nil {
 		web.StatusInternalServerError(w, err)
-		return
 	}
 
 	json.NewEncoder(w).Encode(post)

--- a/server/src/api/forum/posts/h_get.go
+++ b/server/src/api/forum/posts/h_get.go
@@ -1,4 +1,4 @@
-package forum
+package posts
 
 import (
 	"encoding/json"
@@ -30,7 +30,7 @@ func (s *service) get(w http.ResponseWriter, r *http.Request) {
 
 	isAdmin := authentication.IsRequestAdmin(r)
 
-	posts, err := s.posts.GetPosts(r.Context(), slug, p.Max, p.Skip, isAdmin, isAdmin)
+	posts, err := s.repo.GetPosts(r.Context(), slug, p.Max, p.Skip, isAdmin, isAdmin)
 	if err != nil {
 		web.StatusInternalServerError(w, err)
 		return

--- a/server/src/api/forum/posts/h_patch.go
+++ b/server/src/api/forum/posts/h_patch.go
@@ -1,33 +1,32 @@
-package forum
+package posts
 
 import (
 	"encoding/json"
 	"net/http"
 
 	"github.com/go-chi/chi"
-
 	"github.com/openmultiplayer/web/server/src/authentication"
 	"github.com/openmultiplayer/web/server/src/web"
 )
 
-type postPostBody struct {
-	Body    string `json:"body"   valid:"required,stringlength(1|65535)"`
-	ReplyTo string `json:"replyTo"`
+type patchBody struct {
+	Title string `json:"title" valid:"stringlength(1|64)"`
+	Body  string `json:"body"  valid:"stringlength(1|65535)"`
 }
 
-func (s *service) postPost(w http.ResponseWriter, r *http.Request) {
+func (s *service) patch(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	info, ok := authentication.GetAuthenticationInfo(w, r)
 	if !ok {
 		return
 	}
 
-	var b postPostBody
+	var b patchBody
 	if !web.ParseBody(w, r, &b) {
 		return
 	}
 
-	post, err := s.posts.CreatePost(r.Context(), b.Body, info.Cookie.UserID, id, b.ReplyTo)
+	post, err := s.repo.EditPost(r.Context(), info.Cookie.UserID, id, &b.Title, &b.Body)
 	if err != nil {
 		web.StatusInternalServerError(w, err)
 		return

--- a/server/src/api/forum/posts/h_post.go
+++ b/server/src/api/forum/posts/h_post.go
@@ -1,24 +1,36 @@
-package forum
+package posts
 
 import (
 	"encoding/json"
 	"net/http"
 
 	"github.com/go-chi/chi"
+
 	"github.com/openmultiplayer/web/server/src/authentication"
 	"github.com/openmultiplayer/web/server/src/web"
 )
 
-func (s *service) delete(w http.ResponseWriter, r *http.Request) {
+type postBody struct {
+	Body    string `json:"body"   valid:"required,stringlength(1|65535)"`
+	ReplyTo string `json:"replyTo"`
+}
+
+func (s *service) post(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	info, ok := authentication.GetAuthenticationInfo(w, r)
 	if !ok {
 		return
 	}
 
-	post, err := s.posts.DeletePost(r.Context(), info.Cookie.UserID, id, info.Cookie.Admin)
+	var b postBody
+	if !web.ParseBody(w, r, &b) {
+		return
+	}
+
+	post, err := s.repo.CreatePost(r.Context(), b.Body, info.Cookie.UserID, id, b.ReplyTo)
 	if err != nil {
 		web.StatusInternalServerError(w, err)
+		return
 	}
 
 	json.NewEncoder(w).Encode(post)

--- a/server/src/api/forum/tags/api.go
+++ b/server/src/api/forum/tags/api.go
@@ -1,0 +1,30 @@
+package tags
+
+import (
+	"github.com/go-chi/chi"
+	"github.com/openmultiplayer/web/server/src/resources/forum/tag"
+	"go.uber.org/fx"
+)
+
+type service struct {
+	tags tag.Repository
+}
+
+func Build() fx.Option {
+	return fx.Options(
+		fx.Provide(func(tags tag.Repository) *service {
+			return &service{tags}
+		}),
+		fx.Invoke(func(
+			r chi.Router,
+			s *service,
+
+		) {
+			rtr := chi.NewRouter()
+			r.Mount("/forum/tags", rtr)
+
+			rtr.
+				Get("/", s.get)
+		}),
+	)
+}

--- a/server/src/api/forum/tags/h_get.go
+++ b/server/src/api/forum/tags/h_get.go
@@ -1,4 +1,4 @@
-package forum
+package tags
 
 import (
 	"encoding/json"
@@ -11,7 +11,7 @@ type tagsParams struct {
 	Query string `qstring:"query"`
 }
 
-func (s *service) getTags(w http.ResponseWriter, r *http.Request) {
+func (s *service) get(w http.ResponseWriter, r *http.Request) {
 	var p tagsParams
 	if !web.ParseQuery(w, r, &p) {
 		return

--- a/server/src/api/forum/threads/api.go
+++ b/server/src/api/forum/threads/api.go
@@ -1,0 +1,37 @@
+package threads
+
+import (
+	"github.com/go-chi/chi"
+	"github.com/openmultiplayer/web/server/src/authentication"
+	"github.com/openmultiplayer/web/server/src/resources/forum/thread"
+	"go.uber.org/fx"
+)
+
+type service struct {
+	threads thread.Repository
+}
+
+func Build() fx.Option {
+	return fx.Options(
+		fx.Provide(func(
+			threads thread.Repository,
+		) *service {
+			return &service{threads}
+		}),
+		fx.Invoke(func(
+			r chi.Router,
+			s *service,
+
+		) {
+			rtr := chi.NewRouter()
+			r.Mount("/forum/threads", rtr)
+
+			rtr.
+				Get("/", s.list)
+
+			rtr.
+				With(authentication.MustBeAuthenticated /*ratelimiter.WithRateLimit(5)*/).
+				Post("/", s.post)
+		}),
+	)
+}

--- a/server/src/api/forum/threads/h_list.go
+++ b/server/src/api/forum/threads/h_list.go
@@ -1,4 +1,4 @@
-package forum
+package threads
 
 import (
 	"encoding/json"

--- a/server/src/api/forum/threads/h_post.go
+++ b/server/src/api/forum/threads/h_post.go
@@ -1,4 +1,4 @@
-package forum
+package threads
 
 import (
 	"encoding/json"
@@ -8,20 +8,20 @@ import (
 	"github.com/openmultiplayer/web/server/src/web"
 )
 
-type postThreadBody struct {
+type postBody struct {
 	Title    string   `json:"title"      valid:"required,stringlength(1|64)"`
 	Body     string   `json:"body"       valid:"required,stringlength(1|65535)"`
 	Tags     []string `json:"tags"       valid:"required"`
 	Category string   `json:"category"   valid:"required"`
 }
 
-func (s *service) postThread(w http.ResponseWriter, r *http.Request) {
+func (s *service) post(w http.ResponseWriter, r *http.Request) {
 	info, ok := authentication.GetAuthenticationInfo(w, r)
 	if !ok {
 		return
 	}
 
-	var b postThreadBody
+	var b postBody
 	if !web.ParseBody(w, r, &b) {
 		return
 	}


### PR DESCRIPTION
The /forum endpoint is being overused for threads, posts, categories and tags. This PR splits them out into their own, more RESTful, endpoint structure.