### PR TITLE
add clamped paragraph component

### DIFF
--- a/frontend/src/components/forum/ThreadListItem.tsx
+++ b/frontend/src/components/forum/ThreadListItem.tsx
@@ -4,6 +4,7 @@ import { ChakraProps } from "@chakra-ui/system";
 import { opacify } from "polished";
 import React, { FC } from "react";
 import { Post } from "src/types/_generated_Forum";
+import ClampedParagraph from "../generic/ClampedParagraph";
 import { CategoryName, PostMetadata, PostTitle } from "./common";
 import ThreadAdminMenu from "./ThreadMenu";
 
@@ -60,7 +61,7 @@ const ThreadListItem: FC<Props> = ({ post, sx }) => {
 
           {!post.pinned && (
             <main>
-              <p>{post.short}</p>
+              <ClampedParagraph lines={2}>{post.short}</ClampedParagraph>
             </main>
           )}
         </div>

--- a/frontend/src/components/generic/ClampedParagraph.tsx
+++ b/frontend/src/components/generic/ClampedParagraph.tsx
@@ -1,0 +1,29 @@
+import { FC } from "react";
+
+type Props = {
+  lines?: number;
+};
+
+const ClampedParagraph: FC<Props> = ({ children, lines = 1 }) => {
+  return (
+    <>
+      <p>{children}</p>
+
+      <style jsx>{`
+        p {
+          margin: 0.1em;
+          text-overflow: ellipsis;
+          overflow: hidden;
+
+          display: -webkit-box;
+          -webkit-line-clamp: ${lines};
+          -webkit-box-orient: vertical;
+          max-lines: ${lines};
+          line-clamp: ${lines};
+        }
+      `}</style>
+    </>
+  );
+};
+
+export default ClampedParagraph;

--- a/frontend/src/components/notifications/NotificationsList.tsx
+++ b/frontend/src/components/notifications/NotificationsList.tsx
@@ -13,6 +13,7 @@ import { FC, useCallback } from "react";
 import { Notification } from "src/types/_generated_Notification";
 import { niceDate } from "src/utils/dates";
 import { CardList } from "../generic/CardList";
+import ClampedParagraph from "../generic/ClampedParagraph";
 import { useNotification } from "./hooks";
 
 type Props = {
@@ -66,7 +67,7 @@ const NotificationsList: FC<Props> = ({ notifications, showRead }) => {
       </Flex>
 
       <Flex>
-        <p>{ntf.description}</p>
+        <ClampedParagraph lines={2}>{ntf.description}</ClampedParagraph>
       </Flex>
 
       <Flex as="footer" justifyContent="space-between">


### PR DESCRIPTION
Just a line-clamp paragraph component, not guaranteed to work on older browsers so always use this in a progressively enhanced way, so if the clamp isn't applied, the layout is still fine.