### PR TITLE
Client side rendered posts

### DIFF
--- a/frontend/src/components/forum/IsomorphicMarkdown.tsx
+++ b/frontend/src/components/forum/IsomorphicMarkdown.tsx
@@ -1,0 +1,22 @@
+import { MDXRemote, MDXRemoteSerializeResult } from "next-mdx-remote";
+import React, { FC } from "react";
+import ReactMarkdown from "react-markdown";
+
+type Props = {
+  csr?: string;
+  ssr?: MDXRemoteSerializeResult<Record<string, unknown>>;
+};
+
+const IsomorphicMarkdown: FC<Props> = ({ csr, ssr }) => {
+  if (csr) {
+    return <ReactMarkdown>{csr}</ReactMarkdown>;
+  }
+
+  if (ssr) {
+    return <MDXRemote {...ssr}></MDXRemote>;
+  }
+
+  return null;
+};
+
+export default IsomorphicMarkdown;

--- a/frontend/src/components/forum/IsomorphicMarkdown.tsx
+++ b/frontend/src/components/forum/IsomorphicMarkdown.tsx
@@ -1,22 +1,33 @@
 import { MDXRemote, MDXRemoteSerializeResult } from "next-mdx-remote";
 import React, { FC } from "react";
 import ReactMarkdown from "react-markdown";
+import ErrorBanner from "../ErrorBanner";
 
 type Props = {
-  csr?: string;
   ssr?: MDXRemoteSerializeResult<Record<string, unknown>>;
+  csr?: string;
 };
 
-const IsomorphicMarkdown: FC<Props> = ({ csr, ssr }) => {
-  if (csr) {
-    return <ReactMarkdown>{csr}</ReactMarkdown>;
-  }
-
+const IsomorphicMarkdown: FC<Props> = ({ ssr, csr }) => {
   if (ssr) {
     return <MDXRemote {...ssr}></MDXRemote>;
   }
 
-  return null;
+  if (csr) {
+    return <ReactMarkdown>{csr}</ReactMarkdown>;
+  }
+
+  console.warn(
+    "IsomorphicMarkdown received neither csr or ssr props so it's rendering nothing. Ensure the parent is passing both optional server side rendered markdown (which isn't present during a client side page transition) and raw markdown direct from an SWR call (which should ALWAYS be present, regardless of client or server render)"
+  );
+
+  return (
+    <ErrorBanner
+      message="Markdown content was missing at the time of render."
+      suggested="Please report this issue to a team member. Make sure to include the page URL and some details about how you encountered this problem."
+      error="The IsomorphicMarkdown component was not provided with either server side or client side rendered markdown content."
+    />
+  );
 };
 
 export default IsomorphicMarkdown;

--- a/frontend/src/components/forum/IsomorphicMarkdown.tsx
+++ b/frontend/src/components/forum/IsomorphicMarkdown.tsx
@@ -8,13 +8,34 @@ type Props = {
   csr?: string;
 };
 
+const Wrapper: FC = ({ children }) => (
+  <>
+    <div className="isomorphic-markdown-container">{children}</div>
+
+    <style jsx global>{`
+      .isomorphic-markdown-container > * {
+        padding: revert;
+        margin: revert;
+      }
+    `}</style>
+  </>
+);
+
 const IsomorphicMarkdown: FC<Props> = ({ ssr, csr }) => {
   if (ssr) {
-    return <MDXRemote {...ssr}></MDXRemote>;
+    return (
+      <Wrapper>
+        <MDXRemote {...ssr}></MDXRemote>
+      </Wrapper>
+    );
   }
 
   if (csr) {
-    return <ReactMarkdown>{csr}</ReactMarkdown>;
+    return (
+      <Wrapper>
+        <ReactMarkdown>{csr}</ReactMarkdown>
+      </Wrapper>
+    );
   }
 
   console.warn(

--- a/frontend/src/components/forum/PostEditor.tsx
+++ b/frontend/src/components/forum/PostEditor.tsx
@@ -47,6 +47,7 @@ const PostEditor: FC<Props> = ({
   placeholder = "Your post content...",
 }) => {
   const [body, setBody] = useState(initialBody);
+  const [resetKey, setResetKey] = useState(Math.random());
   const [tags, setTags] = useState<string[]>([]);
   const [category, setCategory] = useState("General");
   const { register, handleSubmit } = useForm({
@@ -66,6 +67,8 @@ const PostEditor: FC<Props> = ({
         tags,
         category,
       });
+      // Trigger the editor to re-render and clear its content.
+      setResetKey(Math.random());
     },
     [initialPostID, initialTitle, onSubmit, body, tags, category]
   );
@@ -115,6 +118,7 @@ const PostEditor: FC<Props> = ({
             minHeight="12em"
           >
             <Editor
+              key={resetKey}
               className="mv2"
               defaultValue={initialBody}
               onChange={onChange}

--- a/frontend/src/components/forum/PostList.tsx
+++ b/frontend/src/components/forum/PostList.tsx
@@ -1,0 +1,27 @@
+import { map } from "lodash/fp";
+import { FC } from "react";
+import { Post } from "src/types/_generated_Forum";
+import { CardList } from "../generic/CardList";
+import PostListItem, { PostWithMarkdown } from "./PostListItem";
+
+const PostList: FC<{
+  thread: Partial<Post>;
+  posts: PostWithMarkdown[];
+  onSetReply: (post: Post) => void;
+}> = ({ thread, posts, onSetReply }) => {
+  return (
+    <CardList>
+      {map((post: PostWithMarkdown) => (
+        <PostListItem
+          key={post.id}
+          thread={thread}
+          post={post}
+          showAdminTools={true}
+          onSetReply={onSetReply}
+        />
+      ))(posts)}
+    </CardList>
+  );
+};
+
+export default PostList;

--- a/frontend/src/components/forum/hooks.ts
+++ b/frontend/src/components/forum/hooks.ts
@@ -121,8 +121,8 @@ export const useCreatePost = (
   replyTo?: Post
 ): CreatePostFn => {
   const toast = useToast();
+  const { mutate } = useSWRConfig();
   const handler = useErrorHandler();
-  const router = useRouter();
   const onSubmit = useCallback(
     async (data: PostPayload) => {
       if (isPostEmpty(data)) {
@@ -139,12 +139,12 @@ export const useCreatePost = (
           title: "Reply sent!",
           status: "success",
         });
-        router.push(`/discussion/${slug}`);
+        mutate(`/forum/posts/${slug}`);
       } catch (e) {
         handler(e);
       }
     },
-    [toast, handler, router, id, slug, replyTo]
+    [toast, handler, mutate, id, slug, replyTo]
   );
 
   return onSubmit;
@@ -175,7 +175,7 @@ export const useDeletePost = (): DeleteFn => {
   return onDelete;
 };
 
-export const useEditPost = (): EditFn => {
+export const useEditPost = (slug?: string): EditFn => {
   const toast = useToast();
   const { mutate } = useSWRConfig();
   const handler = useErrorHandler();
@@ -194,10 +194,10 @@ export const useEditPost = (): EditFn => {
       } catch (e) {
         handler(e);
       }
-      mutate("/forum");
+      mutate(`/forum/posts/${slug}`);
       nProgress.done();
     },
-    [handler, toast, mutate]
+    [handler, toast, mutate, slug]
   );
 
   return onEdit;


### PR DESCRIPTION
introduce IsomorphicMarkdown component
    
This component can be used to render either server-side-rendered markdown content that was previously serialised via next-mdx-remote or render a simple string of markdown text present on the client.
    
This is primarily necessary for client-side updates of content (replying to threads and editing posts) - the initial render uses SSR markdown, then subsequent renders use whatever markdown state that is updated when its parent re-renders.
