### PR TITLE
rewritten the api fetcher functions to be more readable and ergonomic

### DIFF
--- a/frontend/src/auth/hooks.tsx
+++ b/frontend/src/auth/hooks.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from "react";
 
-import { apiSSP } from "src/fetcher/fetcher";
+import { api } from "src/fetcher/fetcher";
 import { User, UserSchema } from "src/types/_generated_User";
 
 type AuthenticationContext = {
@@ -26,7 +26,7 @@ export const AuthProvider: FunctionComponent = ({ children }) => {
   React.useEffect(() => {
     const initializeAuth = async () => {
       try {
-        const user = await apiSSP("/users/self", { schema: UserSchema });
+        const user = await api("/users/self", { schema: UserSchema });
         setAuthenticated(true);
         setUser(user);
       } catch (_) {

--- a/frontend/src/components/forum/CategoryListView.tsx
+++ b/frontend/src/components/forum/CategoryListView.tsx
@@ -9,7 +9,7 @@ import Measured from "../Measured";
 import CategoryList from "./CategoryList";
 
 type Props = {
-  initialCategories: Category[];
+  initialCategories?: Category[];
 };
 
 const CategoryListView: FC<Props> = ({ initialCategories }) => {

--- a/frontend/src/components/forum/PostEditor.tsx
+++ b/frontend/src/components/forum/PostEditor.tsx
@@ -3,7 +3,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { FC, useCallback, useState } from "react";
 import { useForm } from "react-hook-form";
 import Editor from "rich-markdown-editor";
-import { apiSWR } from "src/fetcher/fetcher";
+import { api } from "src/fetcher/fetcher";
 import {
   SearchResults,
   SearchResultsSchema,
@@ -130,10 +130,10 @@ const PostEditor: FC<Props> = ({
                 "placeholder",
               ]}
               onSearchLink={async (term: string) => {
-                // TODO: FIX THIS
-                const result = await apiSWR<SearchResults>({
-                  schema: SearchResultsSchema,
-                })(`/docs/search?q=${term}`);
+                const result = await api<SearchResults>(
+                  `/docs/search?q=${term}`,
+                  { schema: SearchResultsSchema }
+                );
                 return result.hits.map((hit) => ({
                   title: hit.title,
                   subtitle: hit.desc,

--- a/frontend/src/components/forum/PostListView.tsx
+++ b/frontend/src/components/forum/PostListView.tsx
@@ -16,7 +16,6 @@ import PostList from "./PostList";
 import { PostWithMarkdown } from "./PostListItem";
 
 type Props = {
-  id: string;
   slug: string;
   initialPosts?: PostWithMarkdown[];
 };
@@ -75,7 +74,7 @@ const Reply: FC<ReplyProps> = ({ id, slug, post, onCancelReply }) => {
   );
 };
 
-const PostListView: FC<Props> = ({ id, slug, initialPosts }) => {
+const PostListView: FC<Props> = ({ slug, initialPosts }) => {
   const [reply, setReply] = useState<Post | undefined>(undefined);
   const onCancelReply = useCallback(() => setReply(undefined), [setReply]);
   const onSetReply = useCallback((post: Post) => setReply(post), [setReply]);
@@ -91,6 +90,8 @@ const PostListView: FC<Props> = ({ id, slug, initialPosts }) => {
   if (!data) {
     return <LoadingBanner />;
   }
+
+  const id = data[0].id;
 
   return (
     <Measured>

--- a/frontend/src/components/forum/TagsInput.tsx
+++ b/frontend/src/components/forum/TagsInput.tsx
@@ -15,7 +15,7 @@ import React, {
   FocusEvent,
   KeyboardEvent,
 } from "react";
-import { apiSWR } from "src/fetcher/fetcher";
+import { api } from "src/fetcher/fetcher";
 import { TagButton } from "./LinkedTag";
 
 type Tag = {
@@ -138,7 +138,7 @@ class TagsInput extends Component<Props, State> {
   doTagQuery(query: string): void {
     debounce(
       () =>
-        apiSWR<Tag[]>()(`/forum/tags?query=${query}`).then((tags) =>
+        api<Tag[]>(`/forum/tags?query=${query}`).then((tags) =>
           this.setState({ ...this.state, tags: tags ?? [], showTags: true })
         ),
       500

--- a/frontend/src/components/forum/ThreadListView.tsx
+++ b/frontend/src/components/forum/ThreadListView.tsx
@@ -63,7 +63,6 @@ const ThreadListView: FC<Props> = ({
     }
   );
   if (error) {
-    console.error(error);
     return <ErrorBanner {...error} />;
   }
   if (!data) {

--- a/frontend/src/components/forum/ThreadListView.tsx
+++ b/frontend/src/components/forum/ThreadListView.tsx
@@ -11,12 +11,14 @@ import Measured from "../Measured";
 import { allOption } from "./CategorySelect";
 
 type Props = {
+  initialPosts?: Post[];
   initialCategory?: string;
   initialTags?: string[];
   initialText?: string;
 };
 
 const ThreadListView: FC<Props> = ({
+  initialPosts,
   initialCategory = "",
   initialTags = [],
   initialText = "",
@@ -55,7 +57,10 @@ const ThreadListView: FC<Props> = ({
         ["query", initialText],
         ...initialTags.map((tag) => ["tags", tag]),
       ]),
-    })
+    }),
+    {
+      fallbackData: initialPosts,
+    }
   );
   if (error) {
     console.error(error);

--- a/frontend/src/components/forum/ThreadListView.tsx
+++ b/frontend/src/components/forum/ThreadListView.tsx
@@ -1,6 +1,5 @@
 import { useRouter } from "next/router";
 import { FC, useCallback, useState } from "react";
-import { useIsAdmin } from "src/auth/hooks";
 import ErrorBanner from "src/components/ErrorBanner";
 import ThreadList from "src/components/forum/ThreadList";
 import LoadingBanner from "src/components/LoadingBanner";
@@ -49,13 +48,14 @@ const ThreadListView: FC<Props> = ({
   );
 
   const { data, error } = useSWR<Post[], APIError>(
-    "/forum/threads?" +
-      new URLSearchParams([
+    "/forum/threads",
+    apiSWR({
+      query: new URLSearchParams([
         ["category", category],
         ["query", initialText],
         ...initialTags.map((tag) => ["tags", tag]),
-      ]).toString(),
-    apiSWR()
+      ]),
+    })
   );
   if (error) {
     console.error(error);

--- a/frontend/src/components/notifications/NotificationsList.tsx
+++ b/frontend/src/components/notifications/NotificationsList.tsx
@@ -1,10 +1,10 @@
 import { DeleteIcon, ViewIcon, ViewOffIcon } from "@chakra-ui/icons";
 import {
+  Box,
   Button,
   CloseButton,
   Flex,
   Heading,
-  Box,
   Stack,
   Text,
 } from "@chakra-ui/react";
@@ -18,14 +18,10 @@ import { useNotification } from "./hooks";
 
 type Props = {
   notifications: Notification[];
-
-  /** @deprecated this is waiting for #462 */
-  showRead: boolean;
 };
 
-const NotificationsList: FC<Props> = ({ notifications, showRead }) => {
-  const { unsubscribe, setRead, deleteNotification } =
-    useNotification(showRead);
+const NotificationsList: FC<Props> = ({ notifications }) => {
+  const { unsubscribe, setRead, deleteNotification } = useNotification();
 
   const onUnsub = useCallback(
     (id?: string) => id && unsubscribe(id),

--- a/frontend/src/components/notifications/NotificationsView.tsx
+++ b/frontend/src/components/notifications/NotificationsView.tsx
@@ -21,8 +21,11 @@ const NotificationsView: FC = () => {
   );
 
   const { data, error } = useSWR<Notification[], APIError>(
-    `/subscriptions/notifications?read=${showRead}`,
-    apiSWR({ schema: NotificationSchema.array() })
+    `/subscriptions/notifications`,
+    apiSWR({
+      schema: NotificationSchema.array(),
+      query: new URLSearchParams({ read: `${showRead}` }),
+    })
   );
   if (error) {
     return <ErrorBanner {...error} />;
@@ -64,7 +67,7 @@ const NotificationsView: FC = () => {
           Show Read Notifications
         </Checkbox>
       </Flex>
-      <NotificationsList notifications={data} showRead={showRead} />;
+      <NotificationsList notifications={data} />;
     </Stack>
   );
 };

--- a/frontend/src/components/notifications/SubscriptionsList.tsx
+++ b/frontend/src/components/notifications/SubscriptionsList.tsx
@@ -10,7 +10,7 @@ type Props = {
 };
 
 const SubscriptionsList: FC<Props> = ({ subscriptions }) => {
-  const { unsubscribe } = useNotification(false);
+  const { unsubscribe } = useNotification();
 
   const onUnsub = useCallback(
     (id: string) => {

--- a/frontend/src/components/notifications/hooks.ts
+++ b/frontend/src/components/notifications/hooks.ts
@@ -6,10 +6,7 @@ type UnsubscribeFn = (subId: string) => void;
 type SetReadFn = (id: string, read: boolean) => void;
 type DeleteFn = (id: string) => void;
 
-export const useNotification = (
-  // Temporary, see issue #462.
-  showRead: boolean
-): {
+export const useNotification = (): {
   subscribe: SubscribeFn;
   unsubscribe: UnsubscribeFn;
   setRead: SetReadFn;
@@ -20,49 +17,49 @@ export const useNotification = (
   const subscribe = useCallback(
     async (refersType: string, refersTo: string) =>
       api("POST", "/subscriptions", {
-        mutate: `/subscriptions/notifications?read=${showRead}`,
+        mutate: `/subscriptions/notifications`,
         toast: {
           title: `Subscribed!`,
           status: "success",
         },
       })({ refersType, refersTo }),
-    [api, showRead]
+    [api]
   );
 
   const unsubscribe = useCallback(
     async (subId: string) =>
       api("DELETE", `/subscriptions/${subId}`, {
-        mutate: `/subscriptions/notifications?read=${showRead}`,
+        mutate: `/subscriptions/notifications`,
         toast: {
           title: `Unsubscribed!`,
           status: "success",
         },
       })(),
-    [api, showRead]
+    [api]
   );
 
   const setRead = useCallback(
     async (id: string, read: boolean) =>
       api("PATCH", `/subscriptions/notifications/${id}`, {
-        mutate: `/subscriptions/notifications?read=${showRead}`,
+        mutate: `/subscriptions/notifications`,
         toast: {
           title: `Marked ${read ? "read" : "unread"}!`,
           status: "success",
         },
       })({ read }),
-    [api, showRead]
+    [api]
   );
 
   const deleteNotification = useCallback(
     async (id: string) =>
       api("DELETE", `/subscriptions/notifications/${id}`, {
-        mutate: `/subscriptions/notifications?read=${showRead}`,
+        mutate: `/subscriptions/notifications`,
         toast: {
           title: `Deleted notification!`,
           status: "success",
         },
       })(),
-    [api, showRead]
+    [api]
   );
 
   return { subscribe, unsubscribe, setRead, deleteNotification };

--- a/frontend/src/fetcher/fetcher.ts
+++ b/frontend/src/fetcher/fetcher.ts
@@ -5,28 +5,87 @@ import { APIError, APIErrorSchema } from "src/types/_generated_Error";
 import { niceDate } from "src/utils/dates";
 import { ZodSchema } from "zod";
 
-const success = (code: number) => code >= 200 && code <= 299;
+const isSuccessStatus = (code: number) => code >= 200 && code <= 299;
 
-export interface APIOptions<T> {
-  // pass ctx from GSSP for server side cookies
-  ctx?: GetServerSidePropsContext;
+const DEFAULT_HEADERS = {
+  "Content-Type": "application/json",
+};
 
-  // encode headers into response object under `headers` key
-  responseHeaders?: boolean;
-
-  // the response schema
+type Opts<T> = {
+  // TODO: Make this mandatory for all `api` calls.
+  // The response object schema to validate against if there are no errors.
   schema?: ZodSchema<T>;
+
+  // Query parameters, do not add these to the path manually when using swr.
+  query?: URLSearchParams;
+};
+
+export type APIOptions<T> = Opts<T> & RequestInit;
+
+// For general use API calls
+//
+// Builds a request and executes it, then processes the result by checking for
+// errors, checking for rate limit violations and parsing the response using a
+// supplied schema in the options.
+//
+export async function api<T>(path: string, opts?: APIOptions<T>): Promise<T> {
+  const withQuery = `${path}${opts?.query ? "?" + opts.query.toString() : ""}`;
+  const request = buildRequest(withQuery, opts);
+  const response = await fetch(request);
+  const data = await getData(response);
+
+  if (!isSuccessStatus(response.status)) {
+    handleError(data, response, path);
+  }
+
+  return opts?.schema?.parse(data) ?? (data as T);
 }
 
-export type MaybeWithHeaders<T> = T | (T & { headers: Headers });
+/**
+ * Build a request for the API server for use on either the server or client.
+ * @param path The API path endpoint to call
+ * @param opts Request options
+ * @returns A Request object ready for use with `fetch`
+ */
+export const buildRequest = (path: string, opts?: RequestInit): Request => {
+  const req = new Request(`${API_ADDRESS}${path}`, {
+    mode: "cors",
+    credentials: "include",
+    ...DEFAULT_HEADERS,
+    ...opts,
+  });
+  console.debug("Built request for", path, ":", req);
+  return req;
+};
+
+const getData = async (response: Response): Promise<unknown> => {
+  if (isJSON(response)) {
+    return response.json();
+  }
+  throw new Error("Unexpected non-JSON response");
+};
+
+const isJSON = (response: Response): boolean => {
+  const contentType = response.headers.get("Content-Type");
+  return contentType === "application/json";
+};
+
+function handleError(raw: unknown, r: Response, path: string): never {
+  if (r.status === 429) {
+    throw new RateLimitError(r, path);
+  }
+
+  throw deriveError(raw);
+}
 
 // For use in `useSWR` hooks.
 //
 // This is curried in order to remove the need to pass the options on every call
 // because this messes with swr's dependency code and results in repeated calls.
+//
 export function apiSWR<T>(opts?: APIOptions<T>) {
-  return (path: string): Promise<MaybeWithHeaders<T>> => {
-    return apiSSP<T>(path, opts);
+  return (path: string): Promise<T> => {
+    return api<T>(path, opts);
   };
 }
 
@@ -38,49 +97,52 @@ export function apiSWR<T>(opts?: APIOptions<T>) {
 //
 // When being called from getServerSideProps, the request context may be passed
 // in so cookies are passed along for authentication.
+//
 export async function apiSSP<T>(
   path: string,
+  ctx: GetServerSidePropsContext,
   opts?: RequestInit & APIOptions<T>
-): Promise<T | (T & { headers: Headers })> {
-  // merge any specified headers with an additional cookie header - if given
+): Promise<T> {
   const headers = new Headers({
-    ...{ "Content-Type": "application/json" },
     ...opts?.headers,
-    ...(opts?.ctx?.req.headers.cookie && {
-      cookie: opts?.ctx?.req.headers.cookie,
-    }),
+    ...headersFromContext(ctx),
   });
-
-  const r = await fetch(`${API_ADDRESS}${path}`, {
-    mode: "cors",
-    credentials: "include",
-    headers,
-    ...opts,
+  console.debug("Building SSP headers", headers);
+  return api(path, { ...opts, headers }).catch((e) => {
+    // TODO: Change this function to return { data, error } like SWR. This will
+    // make getServerSideProps calls much more ergonomic and consistent.
+    throw deriveError(e);
   });
-
-  const contentType = r.headers.get("Content-Type");
-  const isJson = contentType === "application/json";
-
-  const raw = isJson ? await r.json() : undefined;
-
-  if (!success(r.status)) {
-    const parsed = APIErrorSchema.safeParse(raw);
-    if (parsed.success) {
-      throw parsed.data;
-    } else if (r.status === 429) {
-      throw new RateLimitError(r, path);
-    } else {
-      throw new Error(`unknown error: ${r.statusText}: ${r.status}`);
-    }
-  } else {
-    const decoded: T = opts?.schema?.parse(raw) ?? raw;
-    if (opts?.responseHeaders) {
-      return { ...decoded, headers: r.headers };
-    } else {
-      return decoded;
-    }
-  }
 }
+/**
+ * Builds a headers object for use in getServerSideProps.
+ * @param ctx Next.js server side props context.
+ * @returns A headers object with the cookies (if any) set correctly.
+ */
+const headersFromContext = (ctx: GetServerSidePropsContext): Headers => {
+  const headers = new Headers();
+
+  if (ctx.req.headers.cookie) {
+    console.debug("Adding cookie to SSP headers", ctx.req.headers.cookie);
+    headers.append("cookie", ctx.req.headers.cookie);
+  }
+
+  return headers;
+};
+
+/**
+ * Derives a consistent error object from exception or response input.
+ * @param e Exception or error response object
+ * @returns An APIError object either parsed from `e` or built from toString
+ */
+const deriveError = (e: unknown): APIError => {
+  const parsed = APIErrorSchema.safeParse(e);
+  if (parsed.success) {
+    return parsed.data;
+  } else {
+    return { message: (e as Error).toString() };
+  }
+};
 
 export class RateLimitError implements APIError {
   public message: string;

--- a/frontend/src/fetcher/fetcher.ts
+++ b/frontend/src/fetcher/fetcher.ts
@@ -5,8 +5,6 @@ import { APIError, APIErrorSchema } from "src/types/_generated_Error";
 import { niceDate } from "src/utils/dates";
 import { ZodSchema } from "zod";
 
-const isSuccessStatus = (code: number) => code >= 200 && code <= 299;
-
 const DEFAULT_HEADERS = {
   "Content-Type": "application/json",
 };
@@ -22,12 +20,22 @@ type Opts<T> = {
 
 export type APIOptions<T> = Opts<T> & RequestInit;
 
-// For general use API calls
-//
-// Builds a request and executes it, then processes the result by checking for
-// errors, checking for rate limit violations and parsing the response using a
-// supplied schema in the options.
-//
+/**
+ * For general use API calls
+ *
+ * Builds a request and executes it, then processes the result by checking for
+ * errors, checking for rate limit violations and parsing the response using a
+ * supplied schema in the options.
+ *
+ * @param path API endpoint
+ * @param opts API options for the schema and query parameters. You don't have
+ *             to use the query parameters here, it's fine to just stick them in
+ *             the path for API calls outside of `useSWR`, though it does make
+ *             it a little more ergonomic. See the `apiSWR` documentation for an
+ *             explanation of why this option exists. The schema is for just for
+ *             the response body JSON. It's optional.
+ * @returns The resulting data from the API call. Throws APIError on failure.
+ */
 export async function api<T>(path: string, opts?: APIOptions<T>): Promise<T> {
   const withQuery = `${path}${opts?.query ? "?" + opts.query.toString() : ""}`;
   const request = buildRequest(withQuery, opts);
@@ -40,6 +48,8 @@ export async function api<T>(path: string, opts?: APIOptions<T>): Promise<T> {
 
   return opts?.schema?.parse(data) ?? (data as T);
 }
+
+const isSuccessStatus = (code: number) => code >= 200 && code <= 299;
 
 /**
  * Build a request for the API server for use on either the server or client.
@@ -54,7 +64,6 @@ export const buildRequest = (path: string, opts?: RequestInit): Request => {
     ...DEFAULT_HEADERS,
     ...opts,
   });
-  console.debug("Built request for", path, ":", req);
   return req;
 };
 
@@ -78,42 +87,127 @@ function handleError(raw: unknown, r: Response, path: string): never {
   throw deriveError(raw);
 }
 
-// For use in `useSWR` hooks.
-//
-// This is curried in order to remove the need to pass the options on every call
-// because this messes with swr's dependency code and results in repeated calls.
-//
+/**
+ * For use in `useSWR` hooks ONLY.
+ *
+ * This is curried in order to remove the need to pass the options on every call
+ * because this messes with swr's dependency code and results in repeated calls.
+ *
+ * @param opts Set the query parameter here, not in the useSWR key if you want
+ *             mutations to be generic and affect page updates regardless of the
+ *             query parameters used for the page.
+ * @returns A fetcher function for the second argument of `useSWR`.
+ */
 export function apiSWR<T>(opts?: APIOptions<T>) {
   return (path: string): Promise<T> => {
     return api<T>(path, opts);
   };
 }
 
-// For use in getServerSideProps.
-//
-// Makes an API call and returns a Result type which is either the specified
-// payload type (T) or an APIError type. The result should be `.unwrap`d in
-// order to access the value or throw the error.
-//
-// When being called from getServerSideProps, the request context may be passed
-// in so cookies are passed along for authentication.
-//
+/**
+ * The server side props discriminated type union. Looks very similar to what
+ * `useSWR` calls to keep things consistent. If success is true, data will be
+ * guaranteed not undefined. Makes things nice and ergonomic in page components.
+ *
+ * Usage:
+ *
+ * ```
+ * type Props = SSP<User>
+ *
+ * const Page: NextPage<Props> = (props) => {
+ *   if(!props.success) { return <ErrorBanner {...props.error} /> }
+ *
+ *   return <UserView fallbackData={props.data} />
+ * }
+ *
+ * export const getServerSideProps: GetServerSideProps<Props> => { ... }
+ * ```
+ */
+export type SSP<T> =
+  | {
+      success: true;
+      data: T;
+    }
+  | {
+      success: false;
+      error: APIError;
+    };
+
+/**
+ * For use in getServerSideProps ONLY!
+ *
+ * Makes an API call and returns a result type which is either the specified
+ * payload type (T) or an APIError type. The result should be returned directly
+ * from getServerSideProps to minimise additional code. If the data needs to be
+ * pre-processed on the server side before being passed, use `mapSSP` inside a
+ * `.then()` chain after the call:
+ *
+ * ```
+ * return {
+ *   props: await apiSSP(...).then(mapSSP((data) => preProcess(data)))
+ * }
+ * ```
+ *
+ * The page component should always have props that include `data?: T` and
+ * `error?: APIError`. Because of the way the `SSP` type works, TypeScript will
+ * know that if `error` is undefined, then `data` must be defined. Check `error`
+ * early in the component's render and return an `<ErrorBanner {...error} />` if
+ * it has a value. Otherwise, `data` is ready to use.
+ *
+ * Most of the time, you'll want to pass `data` into a "View" component which
+ * should make use of `useSWR` - in order to make use of the server side
+ * rendered `data` value, pass this in to useSWR's options under `fallbackData`.
+ *
+ * When being called from getServerSideProps, the request context must be
+ * passed in so cookies are added to the request for authentication purposes.
+ *
+ * @param path API endpoint
+ * @param ctx getServerSideProps context argument (for passing cookies)
+ * @param opts API call options
+ * @returns A discriminated union with data or error (similar to swr) this
+ *
+ */
 export async function apiSSP<T>(
   path: string,
   ctx: GetServerSidePropsContext,
   opts?: RequestInit & APIOptions<T>
-): Promise<T> {
+): Promise<SSP<T>> {
   const headers = new Headers({
     ...opts?.headers,
     ...headersFromContext(ctx),
   });
-  console.debug("Building SSP headers", headers);
-  return api(path, { ...opts, headers }).catch((e) => {
-    // TODO: Change this function to return { data, error } like SWR. This will
-    // make getServerSideProps calls much more ergonomic and consistent.
-    throw deriveError(e);
-  });
+  return api(path, { ...opts, headers })
+    .then((data) => ({
+      success: true as const,
+      data,
+    }))
+    .catch((e) => ({
+      success: false as const,
+      error: deriveError(e),
+    }));
 }
+
+/**
+ * A helper function for running post-processing operations on successful calls
+ * to `apiSSP`. Handles success check boilerplate. For use in apiSSP().then().
+ * @param input The immediate return value of `apiSSP`
+ */
+export function mapSSP<T, U = T>(fn: (input: T) => Promise<U>) {
+  return async (input: SSP<T>): Promise<SSP<U>> => {
+    if (input.success) {
+      // If the API call succeeded, run the function on the data and return a
+      // new SSP result with the new data type U.
+      return {
+        success: true as const,
+        data: await fn(input.data),
+      };
+    } else {
+      // If the API call faled, do nothing and pass the input along unchanged.
+      return input;
+    }
+  };
+}
+
 /**
  * Builds a headers object for use in getServerSideProps.
  * @param ctx Next.js server side props context.
@@ -123,7 +217,6 @@ const headersFromContext = (ctx: GetServerSidePropsContext): Headers => {
   const headers = new Headers();
 
   if (ctx.req.headers.cookie) {
-    console.debug("Adding cookie to SSP headers", ctx.req.headers.cookie);
     headers.append("cookie", ctx.req.headers.cookie);
   }
 
@@ -144,6 +237,11 @@ const deriveError = (e: unknown): APIError => {
   }
 };
 
+/**
+ * This error is thrown when the API responds with a "429 Too Many Requests". It
+ * implements the `APIError` type and fills all the fields with some information
+ * about the rate limit so instances of this class can go into `<ErrorBanner />`
+ */
 export class RateLimitError implements APIError {
   public message: string;
   public error: string;

--- a/frontend/src/fetcher/hooks.ts
+++ b/frontend/src/fetcher/hooks.ts
@@ -2,7 +2,7 @@ import { useToast, UseToastOptions } from "@chakra-ui/toast";
 import nProgress from "nprogress";
 import { useErrorHandler } from "src/utils/useErrorHandler";
 import { useSWRConfig } from "swr";
-import { apiSSP } from "./fetcher";
+import { api } from "./fetcher";
 
 export type UseMutationOptions = {
   mutate?: string;
@@ -27,7 +27,7 @@ export const useMutationAPI = <T, R = T>(): UseMutationAPI<T, R> => {
       const progress = opts?.progress ?? true;
       progress && nProgress.start();
 
-      return apiSSP<R>(path, {
+      return api<R>(path, {
         method: method,
         body: data ? JSON.stringify(data) : undefined,
       })

--- a/frontend/src/pages/about.tsx
+++ b/frontend/src/pages/about.tsx
@@ -2,18 +2,27 @@ import { FC } from "react";
 import { GetServerSideProps } from "next";
 
 import { apiSSP } from "src/fetcher/fetcher";
+import { APIError } from "src/types/_generated_Error";
+import ErrorBanner from "src/components/ErrorBanner";
 
 type Props = {
-  version: string;
+  data: { version: string };
+  error: APIError;
 };
 
-const Page: FC<Props> = ({ version }) => (
-  <section className="center measure-wide">
-    <h1>{`About`}</h1>
-    <h2>API Version</h2>
-    <p>{version}</p>
-  </section>
-);
+const Page: FC<Props> = ({ data: { version }, error }) => {
+  if (error) {
+    return <ErrorBanner {...error} />;
+  }
+
+  return (
+    <section className="center measure-wide">
+      <h1>{`About`}</h1>
+      <h2>API Version</h2>
+      <p>{version}</p>
+    </section>
+  );
+};
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => ({
   props: await apiSSP<Props>("/version", ctx),

--- a/frontend/src/pages/about.tsx
+++ b/frontend/src/pages/about.tsx
@@ -15,8 +15,8 @@ const Page: FC<Props> = ({ version }) => (
   </section>
 );
 
-export const getServerSideProps: GetServerSideProps = async () => ({
-  props: await apiSSP<Props>("/version"),
+export const getServerSideProps: GetServerSideProps = async (ctx) => ({
+  props: await apiSSP<Props>("/version", ctx),
 });
 
 export default Page;

--- a/frontend/src/pages/auth/discord.tsx
+++ b/frontend/src/pages/auth/discord.tsx
@@ -1,7 +1,6 @@
-import React, { FC } from "react";
 import { GetServerSidePropsContext, GetServerSidePropsResult } from "next";
-
-import { apiSSP } from "src/fetcher/fetcher";
+import React, { FC } from "react";
+import { buildRequest } from "src/fetcher/fetcher";
 import { APIError } from "src/types/_generated_Error";
 
 type Props = {
@@ -43,19 +42,17 @@ export const getServerSideProps = async (
   };
 
   try {
-    const response: { headers: Headers } = await apiSSP(
-      "/auth/discord/callback",
-      {
-        method: "post",
-        body: JSON.stringify(payload),
-        headers: {
-          "Content-Type": "application/json",
-          Cookie: ctx?.req?.headers?.cookie ?? "",
-        },
-        credentials: "include",
-        responseHeaders: true,
-      }
-    );
+    const request = buildRequest("/auth/discord/callback", {
+      method: "post",
+      body: JSON.stringify(payload),
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: ctx?.req?.headers?.cookie ?? "",
+      },
+      credentials: "include",
+    });
+
+    const response = await fetch(request);
 
     const cookie = response.headers.get("set-cookie");
     if (cookie == null) {

--- a/frontend/src/pages/auth/github.tsx
+++ b/frontend/src/pages/auth/github.tsx
@@ -1,7 +1,6 @@
-import React, { FC } from "react";
 import { GetServerSidePropsContext, GetServerSidePropsResult } from "next";
-
-import { apiSSP } from "src/fetcher/fetcher";
+import React, { FC } from "react";
+import { buildRequest } from "src/fetcher/fetcher";
 import { APIError } from "src/types/_generated_Error";
 
 type Props = {
@@ -43,19 +42,16 @@ export const getServerSideProps = async (
   };
 
   try {
-    const response: { headers: Headers } = await apiSSP(
-      "/auth/github/callback",
-      {
-        method: "post",
-        body: JSON.stringify(payload),
-        headers: {
-          "Content-Type": "application/json",
-          Cookie: ctx?.req?.headers?.cookie ?? "",
-        },
-        credentials: "include",
-        responseHeaders: true,
-      }
-    );
+    const request = buildRequest("/auth/github/callback", {
+      method: "post",
+      body: JSON.stringify(payload),
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: ctx?.req?.headers?.cookie ?? "",
+      },
+      credentials: "include",
+    });
+    const response = await fetch(request);
 
     const cookie = response.headers.get("set-cookie");
     if (cookie == null) {

--- a/frontend/src/pages/discussion/[slug].tsx
+++ b/frontend/src/pages/discussion/[slug].tsx
@@ -47,8 +47,7 @@ export async function getServerSideProps(
   }
 
   try {
-    const posts = await apiSSP<Post[]>(`/forum/posts/${slug}`, {
-      ctx,
+    const posts = await apiSSP<Post[]>(`/forum/posts/${slug}`, ctx, {
       schema: PostSchema.array(),
     });
 

--- a/frontend/src/pages/discussion/category/index.tsx
+++ b/frontend/src/pages/discussion/category/index.tsx
@@ -1,32 +1,24 @@
 import { GetServerSideProps, NextPage } from "next";
+import ErrorBanner from "src/components/ErrorBanner";
 import CategoryListView from "src/components/forum/CategoryListView";
-import { apiSSP } from "src/fetcher/fetcher";
+import { apiSSP, SSP } from "src/fetcher/fetcher";
 import { Category, CategorySchema } from "src/types/_generated_Forum";
 
-type Props = {
-  categories: Category[];
-};
+type Props = SSP<Category[]>;
 
-const Page: NextPage<Props> = ({ categories }) => {
-  return <CategoryListView initialCategories={categories} />;
+const Page: NextPage<Props> = (props) => {
+  if (!props.success) {
+    return <ErrorBanner {...props.error} />;
+  }
+  return <CategoryListView initialCategories={props.data} />;
 };
 
 export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
-  try {
-    return {
-      props: {
-        categories: await apiSSP<Category[]>("/forum/categories", ctx, {
-          schema: CategorySchema.array(),
-        }),
-      },
-    };
-  } catch (e) {
-    return {
-      props: {
-        categories: [],
-      },
-    };
-  }
+  return {
+    props: await apiSSP<Category[]>("/forum/categories", ctx, {
+      schema: CategorySchema.array(),
+    }),
+  };
 };
 
 export default Page;

--- a/frontend/src/pages/discussion/category/index.tsx
+++ b/frontend/src/pages/discussion/category/index.tsx
@@ -15,8 +15,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   try {
     return {
       props: {
-        categories: await apiSSP("/forum/categories", {
-          ctx,
+        categories: await apiSSP<Category[]>("/forum/categories", ctx, {
           schema: CategorySchema.array(),
         }),
       },

--- a/frontend/src/pages/docs/search.tsx
+++ b/frontend/src/pages/docs/search.tsx
@@ -36,8 +36,8 @@ const resultToItem = (h: Hit) => (
 
 const Results: FC<Partial<Props>> = ({ query, results }) => {
   const { data, error } = useSWR<SearchResults, APIError>(
-    `/docs/search?q=${query}`,
-    apiSWR(),
+    `/docs/search`,
+    apiSWR({ query: new URLSearchParams({ q: query ?? "" }) }),
     {
       fallbackData: results || undefined,
     }

--- a/frontend/src/pages/docs/search.tsx
+++ b/frontend/src/pages/docs/search.tsx
@@ -92,7 +92,10 @@ export const getServerSideProps = async (
 ): Promise<GetServerSidePropsResult<Props>> => {
   const query = (context.query as Params).q || "";
   try {
-    const response = await apiSSP<SearchResults>(`/docs/search?q=${query}`);
+    const response = await apiSSP<SearchResults>(
+      `/docs/search?q=${query}`,
+      context
+    );
     return { props: { query, results: response, error: "" } };
   } catch (e) {
     const err = e as APIError;

--- a/frontend/src/pages/members/[id].tsx
+++ b/frontend/src/pages/members/[id].tsx
@@ -22,8 +22,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const id = ctx.params?.["id"];
 
   try {
-    const initialData = await apiSSP(`/users/${id}`, {
-      ctx,
+    const initialData = await apiSSP<User>(`/users/${id}`, ctx, {
       schema: UserSchema,
     });
     return {

--- a/frontend/src/pages/members/[id].tsx
+++ b/frontend/src/pages/members/[id].tsx
@@ -2,47 +2,25 @@ import { GetServerSideProps } from "next";
 import { FC } from "react";
 import ErrorBanner from "src/components/ErrorBanner";
 import MemberView from "src/components/member/MemberView";
-import { apiSSP } from "src/fetcher/fetcher";
-import { APIError } from "src/types/_generated_Error";
+import { apiSSP, SSP } from "src/fetcher/fetcher";
 import { User, UserSchema } from "src/types/_generated_User";
 
-type Props = {
-  initialData?: User;
-  initialError?: APIError;
-};
+type Props = SSP<User>;
 
-const Page: FC<Props> = ({ initialData, initialError }) => {
-  if (initialError) {
-    return <ErrorBanner {...initialError} />;
+const Page: FC<Props> = (props) => {
+  if (!props.success) {
+    return <ErrorBanner {...props.error} />;
   }
-  return <MemberView user={initialData} />;
+  return <MemberView user={props.data} />;
 };
 
-export const getServerSideProps: GetServerSideProps = async (ctx) => {
+export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   const id = ctx.params?.["id"];
-
-  try {
-    const initialData = await apiSSP<User>(`/users/${id}`, ctx, {
+  return {
+    props: await apiSSP<User>(`/users/${id}`, ctx, {
       schema: UserSchema,
-    });
-    return {
-      props: {
-        initialData,
-      },
-    };
-  } catch (e) {
-    const err = e as APIError;
-    console.error(err.error);
-    return {
-      props: {
-        initialError: {
-          error: err.error ?? "",
-          message: err.message ?? "",
-          suggested: err.suggested ?? "",
-        },
-      },
-    };
-  }
+    }),
+  };
 };
 
 export default Page;

--- a/frontend/src/pages/members/index.tsx
+++ b/frontend/src/pages/members/index.tsx
@@ -11,7 +11,7 @@ import {
   useToast,
 } from "@chakra-ui/react";
 import useSWR from "swr";
-import { apiSSP, apiSWR } from "src/fetcher/fetcher";
+import { api, apiSWR } from "src/fetcher/fetcher";
 import { User } from "src/types/_generated_User";
 import nProgress from "nprogress";
 import LoadingBanner from "src/components/LoadingBanner";
@@ -48,7 +48,7 @@ const BanModal = ({ users, user, setUsers }: any) => {
   const handleBan = async (id: string) => {
     nProgress.start();
     setUsers(users.filter((user: any) => user.id !== id));
-    await apiSSP(`/users/${user.id}`, { method: "DELETE" });
+    await api(`/users/${user.id}`, { method: "DELETE" });
     toast({
       title: "Operation successful",
       description: `${user.name} has been banned.`,


### PR DESCRIPTION
There's now a new fetcher, just called `api` which is isomorphic. It's much simpler in structure and easier to read. The way options are handled is much simpler, with just the schema and query params unioned with RequestInit.

Context is removed from the general API and instead `apiSSP` takes context as a required parameter.

Exported a request builder function for more specialised use-cases, such as the OAuth logins.

All other return values and APIs remain the same. There will be some future changes to the ergonomics of the API though, such as nicer SSP error handling.