### PR TITLE
fixed pagination component

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,7 +48,6 @@
     "react-nextjs-toast": "^1.2.5",
     "react-sortablejs": "^6.0.0",
     "react-twemoji": "^0.3.0",
-    "react-use-pagination": "^2.0.1",
     "remark-admonitions": "^1.2.1",
     "remark-html": "^13.0.1",
     "remark-parse": "^9.0.0",

--- a/frontend/src/components/forum/PostListView.tsx
+++ b/frontend/src/components/forum/PostListView.tsx
@@ -121,6 +121,7 @@ const PostListView: FC<Props> = ({ slug, initialPosts, initialPage }) => {
   const id = data[0].id;
   const totalItems = data.length;
   const paged = data.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+  const pageIndex = page - 1;
 
   return (
     <Measured>
@@ -129,8 +130,8 @@ const PostListView: FC<Props> = ({ slug, initialPosts, initialPage }) => {
 
         <Pagination
           totalItems={totalItems}
-          initialPage={page}
-          initialPageSize={PAGE_SIZE}
+          initialPaginationIndex={pageIndex}
+          pageSize={PAGE_SIZE}
           onPage={onPage}
         />
 

--- a/frontend/src/components/forum/ThreadListView.tsx
+++ b/frontend/src/components/forum/ThreadListView.tsx
@@ -34,6 +34,10 @@ export type APIQuery = {
 type BrowserQuery = {
   search: string;
   tags: string[];
+
+  /**
+   * Ranges from 1 to n inclusive, user-facing (browser address bar etc.)
+   */
   page: number;
 };
 
@@ -148,8 +152,8 @@ const ThreadListView: FC<Props> = ({
         />
         <Pagination
           totalItems={totalItems}
-          initialPage={offsetToPage(query.offset)}
-          initialPageSize={PAGE_SIZE}
+          initialPaginationIndex={offsetToPaginationIndex(query.offset)}
+          pageSize={PAGE_SIZE}
           onPage={onPage}
         />
       </Stack>
@@ -160,7 +164,10 @@ const ThreadListView: FC<Props> = ({
 const pageToOffset = (page: number) => Math.max(0, page - 1) * PAGE_SIZE;
 
 const offsetToPage = (offset: number | null) =>
-  isNull(offset) ? 1 : Math.floor(offset / PAGE_SIZE);
+  isNull(offset) ? 1 : 1 + Math.floor(offset / PAGE_SIZE);
+
+const offsetToPaginationIndex = (offset: number | null) =>
+  isNull(offset) ? 0 : Math.floor(offset / PAGE_SIZE);
 
 const getPath = (path: string): string => {
   const q = path.indexOf("?");

--- a/frontend/src/components/forum/ThreadListView.tsx
+++ b/frontend/src/components/forum/ThreadListView.tsx
@@ -1,5 +1,4 @@
 import { Stack } from "@chakra-ui/layout";
-import { isNull } from "lodash";
 import { useRouter } from "next/router";
 import { FC, useCallback, useState } from "react";
 import ErrorBanner from "src/components/ErrorBanner";
@@ -11,7 +10,11 @@ import { Category, CategorySchema, Post } from "src/types/_generated_Forum";
 import { queryToParams } from "src/utils/query";
 import useSWR from "swr";
 import Measured from "../generic/Measured";
-import Pagination from "../generic/Pagination";
+import Pagination, {
+  offsetToPage,
+  offsetToPaginationIndex,
+  pageToOffset,
+} from "../generic/Pagination";
 
 export const PAGE_SIZE = 20;
 
@@ -48,7 +51,7 @@ const getBrowserQuery = ({ search, tags, offset }: APIQuery) =>
   queryToParams({
     search: search ?? undefined,
     tags: tags ?? undefined,
-    page: offset ? offsetToPage(offset) : undefined,
+    page: offset ? offsetToPage(PAGE_SIZE)(offset) : undefined,
   } as BrowserQuery);
 
 const ThreadListView: FC<Props> = ({
@@ -69,7 +72,7 @@ const ThreadListView: FC<Props> = ({
     search: initialText,
     tags: initialTags,
     category: initialCategory,
-    offset: pageToOffset(initialPage),
+    offset: pageToOffset(PAGE_SIZE)(initialPage),
     max: PAGE_SIZE,
   });
 
@@ -86,7 +89,10 @@ const ThreadListView: FC<Props> = ({
 
   const onPage = useCallback(
     (page: number) => {
-      updateQueryParameters({ ...query, offset: pageToOffset(page) });
+      updateQueryParameters({
+        ...query,
+        offset: pageToOffset(PAGE_SIZE)(page),
+      });
     },
     [updateQueryParameters, query]
   );
@@ -152,7 +158,9 @@ const ThreadListView: FC<Props> = ({
         />
         <Pagination
           totalItems={totalItems}
-          initialPaginationIndex={offsetToPaginationIndex(query.offset)}
+          initialPaginationIndex={offsetToPaginationIndex(PAGE_SIZE)(
+            query.offset
+          )}
           pageSize={PAGE_SIZE}
           onPage={onPage}
         />
@@ -160,14 +168,6 @@ const ThreadListView: FC<Props> = ({
     </Measured>
   );
 };
-
-const pageToOffset = (page: number) => Math.max(0, page - 1) * PAGE_SIZE;
-
-const offsetToPage = (offset: number | null) =>
-  isNull(offset) ? 1 : 1 + Math.floor(offset / PAGE_SIZE);
-
-const offsetToPaginationIndex = (offset: number | null) =>
-  isNull(offset) ? 0 : Math.floor(offset / PAGE_SIZE);
 
 const getPath = (path: string): string => {
   const q = path.indexOf("?");

--- a/frontend/src/components/generic/Pagination.tsx
+++ b/frontend/src/components/generic/Pagination.tsx
@@ -1,6 +1,7 @@
 import { Button, IconButton } from "@chakra-ui/button";
 import { ArrowLeftIcon, ArrowRightIcon } from "@chakra-ui/icons";
 import { ListItem, OrderedList, Text } from "@chakra-ui/layout";
+import { isNull } from "lodash";
 import { clamp, flow, map, reverse } from "lodash/fp";
 import range from "lodash/range";
 import { FC, useCallback, useState } from "react";
@@ -203,5 +204,20 @@ const generatePageList = (
 
   return [...left, cur, ...right];
 };
+
+export const pageToOffset =
+  (pageSize: number) =>
+  (page: number): number =>
+    Math.max(0, page - 1) * pageSize;
+
+export const offsetToPage =
+  (pageSize: number) =>
+  (offset: number | null): number =>
+    isNull(offset) ? 1 : 1 + Math.floor(offset / pageSize);
+
+export const offsetToPaginationIndex =
+  (pageSize: number) =>
+  (offset: number | null): number =>
+    isNull(offset) ? 0 : Math.floor(offset / pageSize);
 
 export default Pagination;

--- a/frontend/src/components/generic/Pagination.tsx
+++ b/frontend/src/components/generic/Pagination.tsx
@@ -1,76 +1,98 @@
 import { Button, IconButton } from "@chakra-ui/button";
 import { ArrowLeftIcon, ArrowRightIcon } from "@chakra-ui/icons";
 import { ListItem, OrderedList, Text } from "@chakra-ui/layout";
+import { clamp, flow, map, reverse } from "lodash/fp";
 import range from "lodash/range";
-import { FC, useCallback } from "react";
-import { usePagination } from "react-use-pagination";
+import { FC, useCallback, useState } from "react";
 
 type OnPageFn = (page: number) => void;
 
+/**
+ * Page number is user-facing, it starts at 1 and goes to n.
+ */
+type PageNumber = number;
+
+/**
+ * A pagination index is an internal detail, it starts at 0 and goes to n - 1.
+ */
+type PaginationIndex = number;
+
 type Props = {
+  /**
+   * How many individual items are in all the pages.
+   */
   totalItems: number;
-  initialPage: number;
-  initialPageSize: number;
+
+  /**
+   * Pagination index ranges from 0 to items * page size non-inclusive. This
+   * is not the "page" number that users see. This is because the
+   * react-use-pagination library uses zero as an index for some reason.
+   */
+  initialPaginationIndex: PaginationIndex;
+
+  /**
+   * The size of the pages.
+   */
+  pageSize: number;
+
+  /**
+   * Called when the user navigates to another page.
+   */
   onPage: OnPageFn;
 };
 const Pagination: FC<Props> = ({
   totalItems,
-  initialPage,
-  initialPageSize,
+  initialPaginationIndex,
+  pageSize,
   onPage,
 }) => {
-  const {
-    pageSize,
-    setPage,
-    currentPage,
-    previousEnabled,
-    setPreviousPage,
-    nextEnabled,
-    setNextPage,
-  } = usePagination({
-    totalItems,
-    initialPage,
-    initialPageSize,
-  });
+  const [paginationIndex, setPaginationIndex] = useState(
+    initialPaginationIndex
+  );
+  const totalPages: PageNumber = Math.ceil(totalItems / pageSize);
 
-  const _setPreviousPage = useCallback(() => {
-    setPreviousPage();
-    onPage(currentPage - 1);
-  }, [setPreviousPage, onPage, currentPage]);
-  const _setNextPage = useCallback(() => {
-    setNextPage();
-    onPage(currentPage + 1);
-  }, [setNextPage, onPage, currentPage]);
+  const clampPage = clamp(0)(totalPages);
+
   const _onPage = useCallback(
-    (page: number) => {
-      setPage(page);
+    (paginationIndex: PageNumber) => {
+      const page: PageNumber = clampPage(paginationIndex) + 1;
+      setPaginationIndex(paginationIndex);
       onPage(page);
     },
-    [onPage, setPage]
+    [clampPage, setPaginationIndex, onPage]
   );
+  const _setPreviousPage = useCallback(() => {
+    _onPage(paginationIndex - 1);
+  }, [_onPage, paginationIndex]);
+  const _setNextPage = useCallback(() => {
+    _onPage(paginationIndex + 1);
+  }, [_onPage, paginationIndex]);
 
   // don't render anything if the items will fit on a single page.
   if (totalItems <= pageSize) {
     return null;
   }
 
-  const allPages = range(1, Math.ceil(totalItems / pageSize));
+  const allPages = range(0, totalPages);
   const end = allPages.length;
-  const pages =
-    end <= 10
+  const pageIndices =
+    end <= 8
       ? allPages
       : // If there are more than 10 pages, split up the list and only show the
         // first 4 and the last 4 page number in the pagination navigation list.
-        [1, 2, 3, 4, -1, end - 3, end - 2, end - 1, end];
+        generatePageList(paginationIndex, end);
 
-  const list = pages.map((page) =>
-    page === -1 ? (
+  const previousEnabled = initialPaginationIndex > 1;
+  const nextEnabled = initialPaginationIndex < totalPages - 1;
+
+  const list = pageIndices.map((index) =>
+    index === -1 ? (
       <Text>&hellip;</Text>
     ) : (
       <PageButton
-        key={page}
-        page={page}
-        current={currentPage}
+        key={index}
+        index={index}
+        current={paginationIndex}
         onPage={_onPage}
       />
     )
@@ -112,24 +134,74 @@ const Pagination: FC<Props> = ({
 };
 
 type PageButtonProps = {
-  page: number;
+  index: number;
   current: number;
   onPage: OnPageFn;
 };
-const PageButton: FC<PageButtonProps> = ({ page, current, onPage }) => {
-  const onClick = useCallback(() => onPage(page), [onPage, page]);
+const PageButton: FC<PageButtonProps> = ({ index, current, onPage }) => {
+  const onClick = useCallback(() => onPage(index), [onPage, index]);
+
+  // A "page" is in the range 1 to n inclusive an index is 0 to n non-inclusive.
+  const page = index + 1;
 
   return (
     <ListItem>
       <Button
         size="sm"
-        variant={current === page ? "solid" : "outline"}
+        variant={current === index ? "solid" : "outline"}
         onClick={onClick}
       >
         {page}
       </Button>
     </ListItem>
   );
+};
+
+/**
+ *
+ * @param index The current pagination index
+ * @param end The last pagination index
+ * @returns
+ */
+const generatePageList = (
+  cur: PaginationIndex,
+  end: PaginationIndex
+): PaginationIndex[] => {
+  // First, calculate the left-most index which is bounded by half the width of
+  // the pagination strip (9 items, rounded down) this is 4 indices left of the
+  // current with a minimum value of zero. This is needed to calculate the right
+  const _before = Math.max(0, cur - 4);
+  // Now calculate the right-most index, which is...
+  const after = Math.min(
+    end - 1,
+    // the current page index
+    cur + // plus half the pagination strip item count (9) rounded down
+      4 +
+      // then, with any unused slots on the left, because if the user is at page
+      // 2 then there should be 1 item to the left (page 1) and 7 items on the
+      // right, because first + 4 then + 3 because cur - _before = 1
+      (4 -
+        // subtract this from half the pagination width (9) rounded down
+        (cur - _before))
+    // and this gives us the number of items that should be on the right.
+  );
+  // Finally, do the same again for the left, but this time include the same
+  // calculation as above so if the user is on page 17 out of 19, they don't
+  // just see 14, 15, 16, 17 on the left, but all 9 page buttons.
+  const before = Math.max(0, cur - 4 - (4 + (cur - after)));
+
+  // Now simply turn the page indices into an array and return it. The numbers
+  // calculated above are offsets, so the code below just applies those offsets
+  // to the current pagination index by constructing an array and iterating it.
+
+  const left = flow(
+    map((i: number) => cur - 1 - i),
+    reverse // left side needs to be inverted because it goes right-to-left.
+  )(range(cur - before));
+
+  const right = map((i: number) => cur + 1 + i)(range(after - cur));
+
+  return [...left, cur, ...right];
 };
 
 export default Pagination;

--- a/frontend/src/pages/discussion/[slug].tsx
+++ b/frontend/src/pages/discussion/[slug].tsx
@@ -15,13 +15,19 @@ type Props = SSP<Post[]>;
 
 const Page: NextPage<Props> = (props) => {
   const {
-    query: { slug },
+    query: { slug, page },
   } = useRouter();
   if (!props.success) {
     return <ErrorBanner {...props.error} />;
   }
 
-  return <PostListView slug={slug as string} initialPosts={props.data} />;
+  return (
+    <PostListView
+      slug={slug as string}
+      initialPosts={props.data}
+      initialPage={parseInt(page as string)}
+    />
+  );
 };
 
 const serializePostList = async (posts: Post[]): Promise<PostWithMarkdown[]> =>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5642,11 +5642,6 @@ react-twemoji@^0.3.0:
     prop-types "^15.7.2"
     twemoji "^13.0.1"
 
-react-use-pagination@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/react-use-pagination/-/react-use-pagination-2.0.1.tgz#debc6322cd3f14a4cdf082d913f7736d5cbed170"
-  integrity sha512-bo7vI2oZ/+PJJozN7DLWPkewrULLoHb8a6WO3dGudJfEKnj8BVZVbJPkvn5jtydhJ5xi0t0W7xI06XlWUe8Jbw==
-
 react@17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"


### PR DESCRIPTION
removed the old pagination library and just wrote a simpler one - handles generating a page nav properly with a correct distinction between pages (1..n) and pagination indices (0..n-1)

closes #500 