### PR TITLE
Add pt-BR language name

### DIFF
--- a/frontend/src/utils/getLanguageName.ts
+++ b/frontend/src/utils/getLanguageName.ts
@@ -4,6 +4,7 @@ const missingLanguages: Record<string, string> = {
   "zh-tw": "繁體中文",
   "zh-cn": "简体中文",
   "ar-TN": "تونسي",
+  "pt-BR": "Português do Brasil"
 };
 
 const getLanguageName = (short: string) =>


### PR DESCRIPTION
- Add pt-BR on ‘missingLanguages’.
- Fix ISO code appearing on language menu instead of Language name!