### PR TITLE
Add contribution button to doc pages

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,6 @@
 # Frontend
 
-This directory contains the frontend codebase which is a [Next.js](https://nextjs.org/). It's written in TypeScript with some fairly relaxed but standard tsconfig rules (no strict mode).
+This directory contains the [Next.js](https://nextjs.org/) frontend codebase. It's written in TypeScript with some fairly relaxed but standard tsconfig rules (no strict mode).
 
 To learn more about Next.js, take a look at the following resources:
 

--- a/frontend/src/pages/docs/[[...path]].tsx
+++ b/frontend/src/pages/docs/[[...path]].tsx
@@ -18,6 +18,7 @@ type Props = {
   error?: string;
   data?: { [key: string]: any };
   fallback?: boolean;
+  ghUrl?: string;
 };
 
 const Page = (props: Props) => {
@@ -46,6 +47,33 @@ const Page = (props: Props) => {
     );
   }
 
+  const contributeCallToAction = props.fallback ? (
+    <Admonition type="warning" title="Not Translated">
+      <p>
+        This page has not been translated into the language that your
+        browser requested yet. The English content is being shown as a
+        fallback.
+      </p>
+      <p>
+        If you want to contribute a translation for this page then
+        please click{" "}
+        <a href={props.ghUrl}>here</a>.
+      </p>
+    </Admonition>
+  ) : (
+    // TODO: would we want to translate this into the locale selected?
+    <Admonition type="note" title="Help Needed">
+      <p>
+        This wiki is the result of an ongoing community effort —
+        thank you all for helping!
+      </p>
+      <p>
+        If you want to provide changes to this page then please click{" "}
+        <a href={props.ghUrl}>here</a>.
+      </p>
+    </Admonition>
+  );
+
   return (
     <div className="flex flex-column flex-auto items-stretch">
       <NextSeo
@@ -60,20 +88,7 @@ const Page = (props: Props) => {
         </div>
 
         <section className="mw7 pa3 flex-auto">
-          {props.fallback && (
-            <Admonition type="warning" title="Not Translated">
-              <p>
-                This page has not been translated into the language that your
-                browser requested. The English content is being shown as a
-                fallback.
-              </p>
-              <p>
-                If you want to contribute a translation for this page then
-                please click{" "}
-                <a href="https://github.com/openmultiplayer/web">here</a>.
-              </p>
-            </Admonition>
-          )}
+          {!props.error && contributeCallToAction}
           <h1>{props?.data?.title}</h1>
           {/* <MDXRemote {...props.source} components={components} /> */}
           {content}
@@ -142,7 +157,7 @@ import admonitions from "remark-admonitions";
 import { concat, filter, flatten, flow, map } from "lodash/fp";
 // import { serialize } from "next-mdx-remote/serialize";
 
-import { readLocaleDocs } from "src/utils/content";
+import { getDocsGithubUrl, readLocaleDocs } from "src/utils/content";
 import Search from "src/components/Search";
 import { deriveError } from "src/fetcher/fetcher";
 import { renderToString } from "src/mdx-helpers/ssr";
@@ -186,6 +201,7 @@ export async function getStaticProps(
       source: mdxSource,
       data,
       fallback: result.fallback,
+      ghUrl: getDocsGithubUrl(path, !result.fallback, locale),
     },
   };
 }

--- a/frontend/src/utils/content.ts
+++ b/frontend/src/utils/content.ts
@@ -259,7 +259,6 @@ export const readLocaleDocs = async (
 
 // Gets the url for the corresponding docs page name and locale on Github.
 export const getDocsGithubUrl = (name: string, exists: boolean, locale ?: string) => {
-  console.log('name', name, 'locale', locale);
   const translation = locale === 'en' ? '' : `translations/${locale}/`;
   const mode = exists ? "edit" : "new";
   // TODO: are there ways for a new file to fill its content/title?

--- a/frontend/src/utils/content.ts
+++ b/frontend/src/utils/content.ts
@@ -256,3 +256,12 @@ export const readLocaleDocs = async (
 
   throw new Error(`Not found (${name})`);
 };
+
+// Gets the url for the corresponding docs page name and locale on Github.
+export const getDocsGithubUrl = (name: string, exists: boolean, locale ?: string) => {
+  console.log('name', name, 'locale', locale);
+  const translation = locale === 'en' ? '' : `translations/${locale}/`;
+  const mode = exists ? "edit" : "new";
+  // TODO: are there ways for a new file to fill its content/title?
+  return `https://github.com/openmultiplayer/web/${mode}/master/docs/${translation}${name}.md`;
+};


### PR DESCRIPTION
**Notes**
Addresses #396 for all locales. There's some potential follow-ups in those two `TODO` comments. Existing pages go to "edit" mode on that path, new pages go to "new" mode on the path they'd be created in for that locale.

**Testing**
`http://localhost:3000/es/docs/meta/Contributing` -> https://github.com/openmultiplayer/web/new/master/docs/translations/es/meta/Contributing.md
<img width="1552" alt="image" src="https://user-images.githubusercontent.com/108030714/198861129-b5d50309-c0d7-4c72-ab6e-27c2ad2492c9.png">
`http://localhost:3000/es/docs/awesome` -> https://github.com/openmultiplayer/web/edit/master/docs/translations/es/awesome.md
<img width="1552" alt="image" src="https://user-images.githubusercontent.com/108030714/198861121-6efa5c8b-da7c-4303-942f-371cfb192c62.png">
`http://localhost:3000/docs/awesome` -> https://github.com/openmultiplayer/web/edit/master/docs/awesome.md
<img width="1552" alt="image" src="https://user-images.githubusercontent.com/108030714/198861115-90b465a0-7967-4b35-be07-9f0998d8b101.png">