### PR TITLE
fix reference links in note section

### DIFF
--- a/docs/scripting/resources/anglemodes.md
+++ b/docs/scripting/resources/anglemodes.md
@@ -5,7 +5,7 @@ description: SI unit constants for measuring angles.
 
 :::note
 
-These angle modes are used by [floatsin](../functions/Floatsin), [floatcos](../functions/Floatcos), and [floattan](../functions/Floattan).
+These angle modes are used by [floatsin](../functions/floatsin), [floatcos](../functions/floatcos), and [floattan](../functions/floattan).
 
 :::
 

--- a/docs/scripting/resources/pvartypes.md
+++ b/docs/scripting/resources/pvartypes.md
@@ -4,7 +4,7 @@ title: "Pvar Types"
 
 :::info
 
-Types of player variables (also called pvar types) used in [Per-player variable system.](../tutorials/perplayervariablesystem)
+Types of player variables (also called pvar types) used in [Per-player variable system.](../../tutorials/perplayervariablesystem)
 
 :::
 


### PR DESCRIPTION
Links in _Note_ section on page Resources/Angle Modes (https://www.open.mp/docs/scripting/resources/anglemodes) are broken (Error, file not found) but those pages do exist:

- https://www.open.mp/docs/scripting/functions/floatsin
- https://www.open.mp/docs/scripting/functions/floatcos
- https://www.open.mp/docs/scripting/functions/floattan

I guess this should fix it but I am not sure, please check if valid.
