### PR TITLE
Fix Footer Link Color Glitch and Remove SA-MP Website Link

### DIFF
--- a/frontend/src/components/site/Footer.tsx
+++ b/frontend/src/components/site/Footer.tsx
@@ -11,19 +11,13 @@ const footerList = (heading: string, items: Array<Item>) => (
       {map(([path, name]) => (
         <li key={path}>
           <Link href={path}>
-            <a className="link near-white hover-white" target="_blank">
+            <a className="link near-white" target="_blank">
               {name}
             </a>
           </Link>
         </li>
       ))(items)}
     </ul>
-
-    <style jsx>{`
-      a:visited {
-        color: lightblue;
-      }
-    `}</style>
   </div>
 );
 
@@ -48,7 +42,6 @@ const Footer = () => (
       ])}
 
       {footerList("More", [
-        ["https://sa-mp.com", "SA-MP"],
         ["/blog", "Blog"],
         ["https://github.com/openmultiplayer/", "GitHub"],
       ])}


### PR DESCRIPTION
## Proposed Changes:
- Fix the glitchy color in the visited footer links when hovering over them.
- Remove the SA-MP website link from the footer as it has unfortunately been closed.

## Context:
This pull request addresses two issues:

1. **Fixing Color Glitch on Footer Link Hover:**
   - Prior to this change, there was an issue with the color that appeared on the footer links when hovering over them. With this fix, the color now behaves as it should.

2. **Removing SA-MP Website Link from Footer:**
   - Unfortunately, the SA-MP website has been closed and is no longer available. As a result, maintaining a link to it in the footer is no longer relevant and may confuse users. This change removes the link to keep the footer up to date and accurate.

## How to Test:
- To verify the color fix on the footer links, simply hover over the visited footer links and confirm that the color now behaves correctly.
- To confirm the removal of the SA-MP website link, check that it is no longer present in the footer.

Preview of the color glitch:
![Footer glitch preview](https://i.imgur.com/Lr21mV8.gif)

