### PR TITLE
chore: change sa-mp.com links to sa-mp.mp where possible

### DIFF
--- a/app/resources/server/model.go
+++ b/app/resources/server/model.go
@@ -75,7 +75,7 @@ func (server All) Example() All {
 			"mapname":   "San Andreas",
 			"version":   "0.3.7-R2",
 			"weather":   "10",
-			"weburl":    "www.sa-mp.com",
+			"weburl":    "www.sa-mp.mp",
 			"worldtime": "10:00",
 		},
 		Description: &[]string{"An awesome server! Come and play with us."}[0],

--- a/docs/client/CommonClientIssues.md
+++ b/docs/client/CommonClientIssues.md
@@ -32,7 +32,7 @@ Ensure you are not using any disallowed characters in your name (use 0-9, a-z, \
 
 ### Screen sticks at "Connecting to IP:Port..."
 
-The server could be offline, or if you can't connect to any server, disable your firewall and see if it works. If it does, you will need to reconfigure your firwall. It could also be that you are running an outdated version of SA:MP - you can find new versions [here](http://sa-mp.com/download.php).
+The server could be offline, or if you can't connect to any server, disable your firewall and see if it works. If it does, you will need to reconfigure your firwall. It could also be that you are running an outdated version of SA:MP - you can find new versions [here](https://sa-mp.mp/downloads/).
 
 ### I have a modified GTA: San Andreas and SA:MP won't load
 


### PR DESCRIPTION
We now have replace all possible sa-mp.com links to future open.mp and sa-mp.mp links.

Resolves issue #769

Please contribute.