### PR TITLE
Modern SQLite functions docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ prisma/Studio/
 # Sublime Text
 *.sublime-project
 *.sublime-workspace
+# Visual Studio
+*.wsuo

--- a/docs/scripting/functions/DB_ExecuteQuery.md
+++ b/docs/scripting/functions/DB_ExecuteQuery.md
@@ -1,0 +1,120 @@
+---
+title: DB_ExecuteQuery
+description: The function is used to execute an SQL query on an opened SQLite database.
+keywords:
+  - sqlite
+tags: ["sqlite"]
+---
+
+## Description
+
+The function is used to execute an SQL query on an opened SQLite database.
+
+| Name             | Description                                |
+|------------------|--------------------------------------------|
+| DB:db            | The database handle to query.              |
+| const query[]    | The query to execute.                      |
+| OPEN_MP_TAGS:... | Indefinite number of arguments of any tag. |
+
+## Returns
+
+The query result index (starting at 1) if successful, otherwise 0.
+
+## Examples
+
+```c
+// entity_storage.inc
+
+EntityStorage_SpawnAll(DB:connectionHandle)
+{
+    // Select all entries in table "entities"
+    new DBResult:db_result_set = DB_ExecuteQuery(connectionHandle, "SELECT * FROM `entities`");
+
+    // If database result set handle is valid
+    if (db_result_set)
+    {
+        // Do something...
+
+        // Free the result set
+        DB_FreeResultSet(db_result_set);
+    }
+}
+```
+
+```c
+// mode.pwn
+
+#include <entity_storage>
+
+static DB:gDBConnectionHandle;
+
+// ...
+
+public OnGameModeInit()
+{
+    // ...
+
+    // Create a connection to a database
+    gDBConnectionHandle = DB_Open("example.db");
+
+    // If connection to the database exists
+    if (gDBConnectionHandle)
+    {
+        // Successfully created a connection to the database
+        print("Successfully created a connection to database \"example.db\".");
+        EntityStorage_SpawnAll(gDBConnectionHandle);
+    }
+    else
+    {
+        // Failed to create a connection to the database
+        print("Failed to open a connection to database \"example.db\".");
+    }
+
+    // ...
+
+    return 1;
+}
+
+public OnGameModeExit()
+{
+    // Close the connection to the database if connection is open
+    if (DB_Close(gDBConnectionHandle))
+    {
+        // Extra cleanup
+        gDBConnectionHandle = DB:0;
+    }
+
+    // ...
+
+    return 1;
+}
+```
+
+## Notes
+
+:::warning
+
+Always free results by using [DB_FreeResultSet](DB_FreeResultSet)!
+
+:::
+
+## Related Functions
+
+- [DB_Open](DB_Open): Open a connection to an SQLite database
+- [DB_Close](DB_Close): Close the connection to an SQLite database
+- [DB_ExecuteQuery](DB_ExecuteQuery): Query an SQLite database
+- [DB_FreeResultSet](DB_FreeResultSet): Free result memory from a DB_ExecuteQuery
+- [DB_GetRowCount](DB_GetRowCount): Get the number of rows in a result
+- [DB_SelectNextRow](DB_SelectNextRow): Move to the next row
+- [DB_GetFieldCount](DB_GetFieldCount): Get the number of fields in a result
+- [DB_GetFieldName](DB_GetFieldName): Returns the name of a field at a particular index
+- [DB_GetFieldString](DB_GetFieldString): Get content of field with specified ID from current result row
+- [DB_GetFieldStringByName](DB_GetFieldStringByName): Get content of field with specified name from current result row
+- [DB_GetFieldInt](DB_GetFieldInt): Get content of field as an integer with specified ID from current result row
+- [DB_GetFieldIntByName](DB_GetFieldIntByName): Get content of field as an integer with specified name from current result row
+- [DB_GetFieldFloat](DB_GetFieldFloat): Get content of field as a float with specified ID from current result row
+- [DB_GetFieldFloatByName](DB_GetFieldFloatByName): Get content of field as a float with specified name from current result row
+- [DB_GetMemHandle](DB_GetMemHandle): Get memory handle for an SQLite database that was opened with db_open.
+- [DB_GetLegacyDBResult](DB_GetLegacyDBResult): Get memory handle for an SQLite query that was executed with DB_ExecuteQuery.
+- [DB_GetDatabaseConnectionCount](DB_GetDatabaseConnectionCount): The function gets the number of open database connections for debugging purposes.
+- [DB_GetDatabaseResultSetCount](DB_GetDatabaseResultSetCount): The function gets the number of open database results.

--- a/docs/scripting/functions/DB_FreeResultSet.md
+++ b/docs/scripting/functions/DB_FreeResultSet.md
@@ -1,0 +1,110 @@
+---
+title: DB_FreeResultSet
+description: Frees result memory allocated from DB_ExecuteQuery.
+keywords:
+  - sqlite
+tags: ["sqlite"]
+---
+
+## Description
+
+Frees result memory allocated from DB_ExecuteQuery.
+
+| Name              | Description                                                            |
+|-------------------|------------------------------------------------------------------------|
+| DBResult:dbresult | The result set to free allocated by [DB_ExecuteQuery](DB_ExecuteQuery) |
+
+## Returns
+
+Returns 1 if result set handle is valid, otherwise 0.
+
+## Examples
+
+```c
+// entity_storage.inc
+
+EntityStorage_SpawnAll(DB:connectionHandle)
+{
+    // Select all entries in table "entities"
+    new DBResult:db_result_set = DB_ExecuteQuery(connectionHandle, "SELECT * FROM `entities`");
+
+    // If database result set handle is valid
+    if (db_result_set)
+    {
+        // Do something...
+
+        // Free the result set
+        DB_FreeResultSet(db_result_set);
+    }
+}
+```
+
+```c
+// mode.pwn
+
+#include <entity_storage>
+
+static DB:gDBConnectionHandle;
+
+// ...
+
+public OnGameModeInit()
+{
+    // ...
+
+    // Create a connection to a database
+    gDBConnectionHandle = DB_Open("example.db");
+
+    // If connection to the database exists
+    if (gDBConnectionHandle)
+    {
+        // Successfully created a connection to the database
+        print("Successfully created a connection to database \"example.db\".");
+        EntityStorage_SpawnAll(gDBConnectionHandle);
+    }
+    else
+    {
+        // Failed to create a connection to the database
+        print("Failed to open a connection to database \"example.db\".");
+    }
+
+    // ...
+
+    return 1;
+}
+
+public OnGameModeExit()
+{
+    // Close the connection to the database if connection is open
+    if (DB_Close(gDBConnectionHandle))
+    {
+        // Extra cleanup
+        gDBConnectionHandle = DB:0;
+    }
+
+    // ...
+
+    return 1;
+}
+```
+
+## Related Functions
+
+- [DB_Open](DB_Open): Open a connection to an SQLite database
+- [DB_Close](DB_Close): Close the connection to an SQLite database
+- [DB_ExecuteQuery](DB_ExecuteQuery): Query an SQLite database
+- [DB_FreeResultSet](DB_FreeResultSet): Free result memory from a DB_ExecuteQuery
+- [DB_GetRowCount](DB_GetRowCount): Get the number of rows in a result
+- [DB_SelectNextRow](DB_SelectNextRow): Move to the next row
+- [DB_GetFieldCount](DB_GetFieldCount): Get the number of fields in a result
+- [DB_GetFieldName](DB_GetFieldName): Returns the name of a field at a particular index
+- [DB_GetFieldString](DB_GetFieldString): Get content of field with specified ID from current result row
+- [DB_GetFieldStringByName](DB_GetFieldStringByName): Get content of field with specified name from current result row
+- [DB_GetFieldInt](DB_GetFieldInt): Get content of field as an integer with specified ID from current result row
+- [DB_GetFieldIntByName](DB_GetFieldIntByName): Get content of field as an integer with specified name from current result row
+- [DB_GetFieldFloat](DB_GetFieldFloat): Get content of field as a float with specified ID from current result row
+- [DB_GetFieldFloatByName](DB_GetFieldFloatByName): Get content of field as a float with specified name from current result row
+- [DB_GetMemHandle](DB_GetMemHandle): Get memory handle for an SQLite database that was opened with db_open.
+- [DB_GetLegacyDBResult](DB_GetLegacyDBResult): Get memory handle for an SQLite query that was executed with DB_ExecuteQuery.
+- [DB_GetDatabaseConnectionCount](DB_GetDatabaseConnectionCount): The function gets the number of open database connections for debugging purposes.
+- [DB_GetDatabaseResultSetCount](DB_GetDatabaseResultSetCount): The function gets the number of open database results.

--- a/docs/scripting/functions/DB_GetDatabaseConnectionCount.md
+++ b/docs/scripting/functions/DB_GetDatabaseConnectionCount.md
@@ -1,0 +1,34 @@
+---
+title: DB_GetDatabaseConnectionCount
+description: Gets the number of open database connections for debugging purposes.
+keywords:
+  - sqlite
+tags: ["sqlite"]
+---
+
+## Description
+
+The function gets the number of open database connections for debugging purposes.
+
+The function has no parameters.
+
+## Related Functions
+
+- [DB_Open](DB_Open): Open a connection to an SQLite database
+- [DB_Close](DB_Close): Close the connection to an SQLite database
+- [DB_ExecuteQuery](DB_ExecuteQuery): Query an SQLite database
+- [DB_FreeResultSet](DB_FreeResultSet): Free result memory from a DB_ExecuteQuery
+- [DB_GetRowCount](DB_GetRowCount): Get the number of rows in a result
+- [DB_SelectNextRow](DB_SelectNextRow): Move to the next row
+- [DB_GetFieldCount](DB_GetFieldCount): Get the number of fields in a result
+- [DB_GetFieldName](DB_GetFieldName): Returns the name of a field at a particular index
+- [DB_GetFieldString](DB_GetFieldString): Get content of field with specified ID from current result row
+- [DB_GetFieldStringByName](DB_GetFieldStringByName): Get content of field with specified name from current result row
+- [DB_GetFieldInt](DB_GetFieldInt): Get content of field as an integer with specified ID from current result row
+- [DB_GetFieldIntByName](DB_GetFieldIntByName): Get content of field as an integer with specified name from current result row
+- [DB_GetFieldFloat](DB_GetFieldFloat): Get content of field as a float with specified ID from current result row
+- [DB_GetFieldFloatByName](DB_GetFieldFloatByName): Get content of field as a float with specified name from current result row
+- [DB_GetMemHandle](DB_GetMemHandle): Get memory handle for an SQLite database that was opened with db_open.
+- [DB_GetLegacyDBResult](DB_GetLegacyDBResult): Get memory handle for an SQLite query that was executed with DB_ExecuteQuery.
+- [DB_GetDatabaseConnectionCount](DB_GetDatabaseConnectionCount): The function gets the number of open database connections for debugging purposes.
+- [DB_GetDatabaseResultSetCount](DB_GetDatabaseResultSetCount): The function gets the number of open database results.

--- a/docs/scripting/functions/DB_GetDatabaseResultSetCount.md
+++ b/docs/scripting/functions/DB_GetDatabaseResultSetCount.md
@@ -1,0 +1,34 @@
+---
+title: DB_GetDatabaseResultSetCount
+description: Gets the number of open database results
+keywords:
+  - sqlite
+tags: ["sqlite"]
+---
+
+## Description
+
+The function gets the number of open database results.
+
+The function has no parameters.
+
+## Related Functions
+
+- [DB_Open](DB_Open): Open a connection to an SQLite database
+- [DB_Close](DB_Close): Close the connection to an SQLite database
+- [DB_ExecuteQuery](DB_ExecuteQuery): Query an SQLite database
+- [DB_FreeResultSet](DB_FreeResultSet): Free result memory from a DB_ExecuteQuery
+- [DB_GetRowCount](DB_GetRowCount): Get the number of rows in a result
+- [DB_SelectNextRow](DB_SelectNextRow): Move to the next row
+- [DB_GetFieldCount](DB_GetFieldCount): Get the number of fields in a result
+- [DB_GetFieldName](DB_GetFieldName): Returns the name of a field at a particular index
+- [DB_GetFieldString](DB_GetFieldString): Get content of field with specified ID from current result row
+- [DB_GetFieldStringByName](DB_GetFieldStringByName): Get content of field with specified name from current result row
+- [DB_GetFieldInt](DB_GetFieldInt): Get content of field as an integer with specified ID from current result row
+- [DB_GetFieldIntByName](DB_GetFieldIntByName): Get content of field as an integer with specified name from current result row
+- [DB_GetFieldFloat](DB_GetFieldFloat): Get content of field as a float with specified ID from current result row
+- [DB_GetFieldFloatByName](DB_GetFieldFloatByName): Get content of field as a float with specified name from current result row
+- [DB_GetMemHandle](DB_GetMemHandle): Get memory handle for an SQLite database that was opened with db_open.
+- [DB_GetLegacyDBResult](DB_GetLegacyDBResult): Get memory handle for an SQLite query that was executed with DB_ExecuteQuery.
+- [DB_GetDatabaseConnectionCount](DB_GetDatabaseConnectionCount): The function gets the number of open database connections for debugging purposes.
+- [DB_GetDatabaseResultSetCount](DB_GetDatabaseResultSetCount): The function gets the number of open database results.

--- a/docs/scripting/functions/DB_GetFieldCount.md
+++ b/docs/scripting/functions/DB_GetFieldCount.md
@@ -1,0 +1,176 @@
+---
+title: DB_GetFieldCount
+description: Gets the number of fields from the specified result set allocated with `DB_ExecuteQuery`.
+keywords:
+  - sqlite
+tags: ["sqlite"]
+---
+
+## Description
+
+The function gets the number of fields from the specified result set allocated with [DB_ExecuteQuery](DB_ExecuteQuery).
+
+| Name              | Description                                       |
+|-------------------|---------------------------------------------------|
+| DBResult:dbresult | The result of [DB_ExecuteQuery](DB_ExecuteQuery). |
+
+## Returns
+
+The number of fields in the result.
+
+## Example
+
+```c
+// examples.inc
+
+// ...
+
+static FindFieldIndexByName(DBResult:dbResultSet, const fieldName[])
+{
+    // Return value variable with default return value
+    new ret = -1;
+
+    // Field count
+    new field_count = DB_GetFieldCount(dbResultSet);
+
+    // Current field name
+    new current_field_name[32];
+
+    // Iterate through all fields
+    for (new field_index; field_index < field_count; field_index++)
+    {
+        // Get field name
+        if (DB_GetFieldName(dbResultSet, field_index, current_field_name, sizeof current_field_name))
+        {
+            // Compare searched field name to current field name
+            if (!strcmp(fieldName, current_field_name))
+            {
+                // Success, store field index to return value variable
+                ret = field_index;
+
+                // Break out of the loop
+                break;
+            }
+        }
+    }
+
+    // Return found field index or "-1"
+    return ret;
+}
+
+Float:Examples_CalculateSum(DB:dbConnectionHandle)
+{
+    // Return value variable
+    new Float:ret;
+
+    // Database result set
+    new DBResult:db_result_set = DB_ExecuteQuery("SELECT `value` FROM `examples`");
+
+    // If database result set is valid
+    if (db_result_set)
+    {
+        // Get target field index
+        new target_field_index = FindFieldIndexByName(db_result_set, "value");
+
+        // Check if field index is valid
+        if (target_field_index >= 0)
+        {
+            // Do operations
+            do
+            {
+                // Add value from "example" field to the return value variable
+                ret += DB_GetFieldFloat(db_result_set, target_field_index);
+            }
+
+            // While next row could be fetched
+            while (DB_SelectNextRow(db_result_set));
+        }
+
+        // Free result set
+        DB_FreeResultSet(db_result_set);
+    }
+
+    // Return calculated sum
+    return ret;
+}
+```
+
+```c
+// mode.pwn
+
+// ...
+
+#include <examples>
+
+static DB:gDBConnectionHandle;
+
+// ...
+
+public OnGameModeInit()
+{
+    // ...
+
+    // Create a connection to a database
+    gDBConnectionHandle = DB_Open("example.db");
+
+    // If connection to the database exists
+    if (gDBConnectionHandle)
+    {
+        // Successfully created a connection to the database
+        print("Successfully created a connection to database \"example.db\".");
+        printf("Calculated sum: %f", Examples_CalculateSum(gDBConnectionHandle));
+    }
+    else
+    {
+        // Failed to create a connection to the database
+        print("Failed to open a connection to database \"example.db\".");
+    }
+
+    // ...
+
+    return 1;
+}
+
+public OnGameModeExit()
+{
+    // Close the connection to the database if connection is open
+    if (DB_Close(gDBConnectionHandle))
+    {
+        // Extra cleanup
+        gDBConnectionHandle = DB:0;
+    }
+
+    // ...
+
+    return 1;
+}
+```
+
+## Notes
+
+:::warning
+
+Using an invalid handle other than zero will crash your server! Get a valid database connection handle by using [DB_ExecuteQuery](DB_ExecuteQuery).
+
+:::
+
+## Related Functions
+
+- [DB_Open](DB_Open): Open a connection to an SQLite database
+- [DB_Close](DB_Close): Close the connection to an SQLite database
+- [DB_ExecuteQuery](DB_ExecuteQuery): Query an SQLite database
+- [DB_FreeResultSet](DB_FreeResultSet): Free result memory from a DB_ExecuteQuery
+- [DB_GetRowCount](DB_GetRowCount): Get the number of rows in a result
+- [DB_SelectNextRow](DB_SelectNextRow): Move to the next row
+- [DB_GetFieldCount](DB_GetFieldCount): Get the number of fields in a result
+- [DB_GetFieldName](DB_GetFieldName): Returns the name of a field at a particular index
+- [DB_GetFieldString](DB_GetFieldString): Get content of field with specified ID from current result row
+- [DB_GetFieldStringByName](DB_GetFieldStringByName): Get content of field with specified name from current result row
+- [DB_GetFieldInt](DB_GetFieldInt): Get content of field as an integer with specified ID from current result row
+- [DB_GetFieldIntByName](DB_GetFieldIntByName): Get content of field as an integer with specified name from current result row
+- [DB_GetFieldFloat](DB_GetFieldFloat): Get content of field as a float with specified ID from current result row
+- [DB_GetFieldFloatByName](DB_GetFieldFloatByName): Get content of field as a float with specified name from current result row
+- [DB_GetMemHandle](DB_GetMemHandle): Get memory handle for an SQLite database that was opened with db_open.
+- [DB_GetLegacyDBResult](DB_GetLegacyDBResult): Get memory handle for an SQLite query that was executed with DB_ExecuteQuery.
+- [DB_GetDatabaseConnectionCount](DB_GetDatabaseConnectionCount): The function gets the number of open database connections for debugging purposes.
+- [DB_GetDatabaseResultSetCount](DB_GetDatabaseResultSetCount): The function gets the number of open database results.

--- a/docs/scripting/functions/DB_GetFieldFloat.md
+++ b/docs/scripting/functions/DB_GetFieldFloat.md
@@ -1,0 +1,177 @@
+---
+title: DB_GetFieldFloat
+description: Gets the content of a field as a floating point number with the specified field index.
+keywords:
+  - sqlite
+tags: ["sqlite"]
+---
+
+## Description
+
+The function gets the content of a field as a floating point number with the specified field index.
+
+| Name            | Description                      |
+|-----------------|----------------------------------|
+| DBResult:result | The result to get the data from. |
+| field = 0       | The field to get the data from.  |
+
+## Returns
+
+Retrieved value as a floating point number.
+
+## Example
+
+```c
+// examples.inc
+
+// ...
+
+static FindFieldIndexByName(DBResult:dbResultSet, const fieldName[])
+{
+    // Return value variable with default return value
+    new ret = -1;
+
+    // Field count
+    new field_count = DB_GetFieldCount(dbResultSet);
+
+    // Current field name
+    new current_field_name[32];
+
+    // Iterate through all fields
+    for (new field_index; field_index < field_count; field_index++)
+    {
+        // Get field name
+        if (DB_GetFieldName(dbResultSet, field_index, current_field_name, sizeof current_field_name))
+        {
+            // Compare searched field name to current field name
+            if (!strcmp(fieldName, current_field_name))
+            {
+                // Success, store field index to return value variable
+                ret = field_index;
+
+                // Break out of the loop
+                break;
+            }
+        }
+    }
+
+    // Return found field index or "-1"
+    return ret;
+}
+
+Float:Examples_CalculateSum(DB:dbConnectionHandle)
+{
+    // Return value variable
+    new Float:ret;
+
+    // Database result set
+    new DBResult:db_result_set = DB_ExecuteQuery("SELECT `value` FROM `examples`");
+
+    // If database result set is valid
+    if (db_result_set)
+    {
+        // Get target field index
+        new target_field_index = FindFieldIndexByName(db_result_set, "value");
+
+        // Check if field index is valid
+        if (target_field_index >= 0)
+        {
+            // Do operations
+            do
+            {
+                // Add value from "example" field to the return value variable
+                ret += DB_GetFieldFloat(db_result_set, target_field_index);
+            }
+
+            // While next row could be fetched
+            while (DB_SelectNextRow(db_result_set));
+        }
+
+        // Free result set
+        DB_FreeResultSet(db_result_set);
+    }
+
+    // Return calculated sum
+    return ret;
+}
+```
+
+```c
+// mode.pwn
+
+// ...
+
+#include <examples>
+
+static DB:gDBConnectionHandle;
+
+// ...
+
+public OnGameModeInit()
+{
+    // ...
+
+    // Create a connection to a database
+    gDBConnectionHandle = DB_Open("example.db");
+
+    // If connection to the database exists
+    if (gDBConnectionHandle)
+    {
+        // Successfully created a connection to the database
+        print("Successfully created a connection to database \"example.db\".");
+        printf("Calculated sum: %f", Examples_CalculateSum(gDBConnectionHandle));
+    }
+    else
+    {
+        // Failed to create a connection to the database
+        print("Failed to open a connection to database \"example.db\".");
+    }
+
+    // ...
+
+    return 1;
+}
+
+public OnGameModeExit()
+{
+    // Close the connection to the database if connection is open
+    if (DB_Close(gDBConnectionHandle))
+    {
+        // Extra cleanup
+        gDBConnectionHandle = DB:0;
+    }
+
+    // ...
+
+    return 1;
+}
+```
+
+## Notes
+
+:::warning
+
+Using an invalid handle other than zero will crash your server! Get a valid database connection handle by using [DB_ExecuteQuery](DB_ExecuteQuery).
+
+:::
+
+## Related Functions
+
+- [DB_Open](DB_Open): Open a connection to an SQLite database
+- [DB_Close](DB_Close): Close the connection to an SQLite database
+- [DB_ExecuteQuery](DB_ExecuteQuery): Query an SQLite database
+- [DB_FreeResultSet](DB_FreeResultSet): Free result memory from a DB_ExecuteQuery
+- [DB_GetRowCount](DB_GetRowCount): Get the number of rows in a result
+- [DB_SelectNextRow](DB_SelectNextRow): Move to the next row
+- [DB_GetFieldCount](DB_GetFieldCount): Get the number of fields in a result
+- [DB_GetFieldName](DB_GetFieldName): Returns the name of a field at a particular index
+- [DB_GetFieldString](DB_GetFieldString): Get content of field with specified ID from current result row
+- [DB_GetFieldStringByName](DB_GetFieldStringByName): Get content of field with specified name from current result row
+- [DB_GetFieldInt](DB_GetFieldInt): Get content of field as an integer with specified ID from current result row
+- [DB_GetFieldIntByName](DB_GetFieldIntByName): Get content of field as an integer with specified name from current result row
+- [DB_GetFieldFloat](DB_GetFieldFloat): Get content of field as a float with specified ID from current result row
+- [DB_GetFieldFloatByName](DB_GetFieldFloatByName): Get content of field as a float with specified name from current result row
+- [DB_GetMemHandle](DB_GetMemHandle): Get memory handle for an SQLite database that was opened with db_open.
+- [DB_GetLegacyDBResult](DB_GetLegacyDBResult): Get memory handle for an SQLite query that was executed with DB_ExecuteQuery.
+- [DB_GetDatabaseConnectionCount](DB_GetDatabaseConnectionCount): The function gets the number of open database connections for debugging purposes.
+- [DB_GetDatabaseResultSetCount](DB_GetDatabaseResultSetCount): The function gets the number of open database results.

--- a/docs/scripting/functions/DB_GetFieldFloatByName.md
+++ b/docs/scripting/functions/DB_GetFieldFloatByName.md
@@ -1,0 +1,137 @@
+---
+title: DB_GetFieldFloatByName
+description: Gets the contents of the field as a floating point number with the specified field name.
+keywords:
+  - sqlite
+tags: ["sqlite"]
+---
+
+## Description
+
+The function gets the contents of the field as a floating point number from the specified field name.
+
+| Name            | Description                         |
+|-----------------|-------------------------------------|
+| DBResult:result | The result to get the data from     |
+| const field[]   | The field name to get the data from |
+
+## Returns
+
+Retrieved value as floating point number.
+
+## Example
+
+```c
+// examples.inc
+
+// ...
+
+Float:Examples_CalculateSum(DB:dbConnectionHandle)
+{
+    // Return value variable
+    new Float:ret;
+
+    // Database result set
+    new DBResult:db_result_set = DB_ExecuteQuery("SELECT `value` FROM `examples`");
+
+    // If database result set is valid
+    if (db_result_set)
+    {
+        // Do operations
+        do
+        {
+            // Add value from "example" field to the return value variable
+            ret += DB_GetFieldFloatByName(db_result_set, "value");
+        }
+
+        // While next row could be fetched
+        while (DB_SelectNextRow(db_result_set));
+
+        // Free result set
+        DB_FreeResultSet(db_result_set);
+    }
+
+    // Return calculated sum
+    return ret;
+}
+```
+
+```c
+// mode.pwn
+
+// ...
+
+#include <examples>
+
+static DB:gDBConnectionHandle;
+
+// ...
+
+public OnGameModeInit()
+{
+    // ...
+
+    // Create a connection to a database
+    gDBConnectionHandle = DB_Open("example.db");
+
+    // If connection to the database exists
+    if (gDBConnectionHandle)
+    {
+        // Successfully created a connection to the database
+        print("Successfully created a connection to database \"example.db\".");
+        printf("Calculated sum: %f", Examples_CalculateSum(gDBConnectionHandle));
+    }
+    else
+    {
+        // Failed to create a connection to the database
+        print("Failed to open a connection to database \"example.db\".");
+    }
+
+    // ...
+
+    return 1;
+}
+
+public OnGameModeExit()
+{
+    // Close the connection to the database if connection is open
+    if (DB_Close(gDBConnectionHandle))
+    {
+        // Extra cleanup
+        gDBConnectionHandle = DB:0;
+    }
+
+    // ...
+
+    return 1;
+}
+```
+
+## Notes
+
+:::warning
+
+Using an invalid handle other than zero will crash your server! Get a valid database connection handle by using [DB_ExecuteQuery](DB_ExecuteQuery).
+
+:::
+
+## Related Functions
+
+- [DB_Open](DB_Open): Open a connection to an SQLite database
+- [DB_Close](DB_Close): Close the connection to an SQLite database
+- [DB_ExecuteQuery](DB_ExecuteQuery): Query an SQLite database
+- [DB_FreeResultSet](DB_FreeResultSet): Free result memory from a DB_ExecuteQuery
+- [DB_GetRowCount](DB_GetRowCount): Get the number of rows in a result
+- [DB_SelectNextRow](DB_SelectNextRow): Move to the next row
+- [DB_GetFieldCount](DB_GetFieldCount): Get the number of fields in a result
+- [DB_GetFieldName](DB_GetFieldName): Returns the name of a field at a particular index
+- [DB_GetFieldString](DB_GetFieldString): Get content of field with specified ID from current result row
+- [DB_GetFieldStringByName](DB_GetFieldStringByName): Get content of field with specified name from current result row
+- [DB_GetFieldInt](DB_GetFieldInt): Get content of field as an integer with specified ID from current result row
+- [DB_GetFieldIntByName](DB_GetFieldIntByName): Get content of field as an integer with specified name from current result row
+- [DB_GetFieldFloat](DB_GetFieldFloat): Get content of field as a float with specified ID from current result row
+- [DB_GetFieldFloatByName](DB_GetFieldFloatByName): Get content of field as a float with specified name from current result row
+- [DB_GetMemHandle](DB_GetMemHandle): Get memory handle for an SQLite database that was opened with db_open.
+- [DB_GetLegacyDBResult](DB_GetLegacyDBResult): Get memory handle for an SQLite query that was executed with DB_ExecuteQuery.
+- [DB_GetDatabaseConnectionCount](DB_GetDatabaseConnectionCount): The function gets the number of open database connections for debugging purposes.
+- [DB_GetDatabaseResultSetCount](DB_GetDatabaseResultSetCount): The function gets the number of open database results.

--- a/docs/scripting/functions/DB_GetFieldInt.md
+++ b/docs/scripting/functions/DB_GetFieldInt.md
@@ -1,0 +1,177 @@
+---
+title: DB_GetFieldInt
+description: Get the content of a field as an integer from DB_ExecuteQuery.
+keywords:
+  - sqlite
+tags: ["sqlite"]
+---
+
+## Description
+
+Get the content of a field as an integer from DB_ExecuteQuery
+
+| Name            | Description                      |
+|-----------------|----------------------------------|
+| DBResult:result | The result to get the data from. |
+| field = 0       | The field to get the data from.  |
+
+## Returns
+
+Retrieved value as an integer.
+
+## Example
+
+```c
+// examples.inc
+
+// ...
+
+static FindFieldIndexByName(DBResult:dbResultSet, const fieldName[])
+{
+    // Return value variable with default return value
+    new ret = -1;
+
+    // Field count
+    new field_count = DB_GetFieldCount(dbResultSet);
+
+    // Current field name
+    new current_field_name[32];
+
+    // Iterate through all fields
+    for (new field_index; field_index < field_count; field_index++)
+    {
+        // Get field name
+        if (DB_GetFieldName(dbResultSet, field_index, current_field_name, sizeof current_field_name))
+        {
+            // Compare searched field name to current field name
+            if (!strcmp(fieldName, current_field_name))
+            {
+                // Success, store field index to return value variable
+                ret = field_index;
+
+                // Break out of the loop
+                break;
+            }
+        }
+    }
+
+    // Return found field index or "-1"
+    return ret;
+}
+
+Examples_CalculateSum(DB:dbConnectionHandle)
+{
+    // Return value variable
+    new ret;
+
+    // Database result set
+    new DBResult:db_result_set = DB_ExecuteQuery("SELECT `value` FROM `examples`");
+
+    // If database result set is valid
+    if (db_result_set)
+    {
+        // Get target field index
+        new target_field_index = FindFieldIndexByName(db_result_set, "value");
+
+        // Check if field index is valid
+        if (target_field_index >= 0)
+        {
+            // Do operations
+            do
+            {
+                // Add value from "example" field to the return value variable
+                ret += DB_GetFieldInt(db_result_set, target_field_index);
+            }
+
+            // While next row could be fetched
+            while (DB_SelectNextRow(db_result_set));
+        }
+
+        // Free result set
+        DB_FreeResultSet(db_result_set);
+    }
+
+    // Return calculated sum
+    return ret;
+}
+```
+
+```c
+// mode.pwn
+
+// ...
+
+#include <examples>
+
+static DB:gDBConnectionHandle;
+
+// ...
+
+public OnGameModeInit()
+{
+    // ...
+
+    // Create a connection to a database
+    gDBConnectionHandle = DB_Open("example.db");
+
+    // If connection to the database exists
+    if (gDBConnectionHandle)
+    {
+        // Successfully created a connection to the database
+        print("Successfully created a connection to database \"example.db\".");
+        printf("Calculated sum: %d", Examples_CalculateSum(gDBConnectionHandle));
+    }
+    else
+    {
+        // Failed to create a connection to the database
+        print("Failed to open a connection to database \"example.db\".");
+    }
+
+    // ...
+
+    return 1;
+}
+
+public OnGameModeExit()
+{
+    // Close the connection to the database if connection is open
+    if (DB_Close(gDBConnectionHandle))
+    {
+        // Extra cleanup
+        gDBConnectionHandle = DB:0;
+    }
+
+    // ...
+
+    return 1;
+}
+```
+
+## Notes
+
+:::warning
+
+Using an invalid handle other than zero will crash your server! Get a valid database connection handle by using [DB_ExecuteQuery](DB_ExecuteQuery).
+
+:::
+
+## Related Functions
+
+- [DB_Open](DB_Open): Open a connection to an SQLite database
+- [DB_Close](DB_Close): Close the connection to an SQLite database
+- [DB_ExecuteQuery](DB_ExecuteQuery): Query an SQLite database
+- [DB_FreeResultSet](DB_FreeResultSet): Free result memory from a DB_ExecuteQuery
+- [DB_GetRowCount](DB_GetRowCount): Get the number of rows in a result
+- [DB_SelectNextRow](DB_SelectNextRow): Move to the next row
+- [DB_GetFieldCount](DB_GetFieldCount): Get the number of fields in a result
+- [DB_GetFieldName](DB_GetFieldName): Returns the name of a field at a particular index
+- [DB_GetFieldString](DB_GetFieldString): Get content of field with specified ID from current result row
+- [DB_GetFieldStringByName](DB_GetFieldStringByName): Get content of field with specified name from current result row
+- [DB_GetFieldInt](DB_GetFieldInt): Get content of field as an integer with specified ID from current result row
+- [DB_GetFieldIntByName](DB_GetFieldIntByName): Get content of field as an integer with specified name from current result row
+- [DB_GetFieldFloat](DB_GetFieldFloat): Get content of field as a float with specified ID from current result row
+- [DB_GetFieldFloatByName](DB_GetFieldFloatByName): Get content of field as a float with specified name from current result row
+- [DB_GetMemHandle](DB_GetMemHandle): Get memory handle for an SQLite database that was opened with db_open.
+- [DB_GetLegacyDBResult](DB_GetLegacyDBResult): Get memory handle for an SQLite query that was executed with DB_ExecuteQuery.
+- [DB_GetDatabaseConnectionCount](DB_GetDatabaseConnectionCount): The function gets the number of open database connections for debugging purposes.
+- [DB_GetDatabaseResultSetCount](DB_GetDatabaseResultSetCount): The function gets the number of open database results.

--- a/docs/scripting/functions/DB_GetFieldIntByName.md
+++ b/docs/scripting/functions/DB_GetFieldIntByName.md
@@ -1,0 +1,137 @@
+---
+title: DB_GetFieldIntByName
+description: Gets the contents of the field as an integer with the specified field name.
+keywords:
+  - sqlite
+tags: ["sqlite"]
+---
+
+## Description
+
+Get the contents of field as an integer with specified name.
+
+| Name            | Description                        |
+|-----------------|------------------------------------|
+| DBResult:result | The result to get the data from    |
+| const field[]   | The fieldname to get the data from |
+
+## Returns
+
+Retrieved value as an integer.
+
+## Example
+
+```c
+// examples.inc
+
+// ...
+
+Examples_CalculateSum(DB:dbConnectionHandle)
+{
+    // Return value variable
+    new ret;
+
+    // Database result set
+    new DBResult:db_result_set = DB_ExecuteQuery("SELECT `value` FROM `examples`");
+
+    // If database result set is valid
+    if (db_result_set)
+    {
+        // Do operations
+        do
+        {
+            // Add value from "example" field to the return value variable
+            ret += DB_GetFieldIntByName(db_result_set, "value");
+        }
+
+        // While next row could be fetched
+        while (DB_SelectNextRow(db_result_set));
+
+        // Free result set
+        DB_FreeResultSet(db_result_set);
+    }
+
+    // Return calculated sum
+    return ret;
+}
+```
+
+```c
+// mode.pwn
+
+// ...
+
+#include <examples>
+
+static DB:gDBConnectionHandle;
+
+// ...
+
+public OnGameModeInit()
+{
+    // ...
+
+    // Create a connection to a database
+    gDBConnectionHandle = DB_Open("example.db");
+
+    // If connection to the database exists
+    if (gDBConnectionHandle)
+    {
+        // Successfully created a connection to the database
+        print("Successfully created a connection to database \"example.db\".");
+        printf("Calculated sum: %d", Examples_CalculateSum(gDBConnectionHandle));
+    }
+    else
+    {
+        // Failed to create a connection to the database
+        print("Failed to open a connection to database \"example.db\".");
+    }
+
+    // ...
+
+    return 1;
+}
+
+public OnGameModeExit()
+{
+    // Close the connection to the database if connection is open
+    if (DB_Close(gDBConnectionHandle))
+    {
+        // Extra cleanup
+        gDBConnectionHandle = DB:0;
+    }
+
+    // ...
+
+    return 1;
+}
+```
+
+## Notes
+
+:::warning
+
+Using an invalid handle other than zero will crash your server! Get a valid database connection handle by using [DB_ExecuteQuery](DB_ExecuteQuery).
+
+:::
+
+## Related Functions
+
+- [DB_Open](DB_Open): Open a connection to an SQLite database
+- [DB_Close](DB_Close): Close the connection to an SQLite database
+- [DB_ExecuteQuery](DB_ExecuteQuery): Query an SQLite database
+- [DB_FreeResultSet](DB_FreeResultSet): Free result memory from a DB_ExecuteQuery
+- [DB_GetRowCount](DB_GetRowCount): Get the number of rows in a result
+- [DB_SelectNextRow](DB_SelectNextRow): Move to the next row
+- [DB_GetFieldCount](DB_GetFieldCount): Get the number of fields in a result
+- [DB_GetFieldName](DB_GetFieldName): Returns the name of a field at a particular index
+- [DB_GetFieldString](DB_GetFieldString): Get content of field with specified ID from current result row
+- [DB_GetFieldStringByName](DB_GetFieldStringByName): Get content of field with specified name from current result row
+- [DB_GetFieldInt](DB_GetFieldInt): Get content of field as an integer with specified ID from current result row
+- [DB_GetFieldIntByName](DB_GetFieldIntByName): Get content of field as an integer with specified name from current result row
+- [DB_GetFieldFloat](DB_GetFieldFloat): Get content of field as a float with specified ID from current result row
+- [DB_GetFieldFloatByName](DB_GetFieldFloatByName): Get content of field as a float with specified name from current result row
+- [DB_GetMemHandle](DB_GetMemHandle): Get memory handle for an SQLite database that was opened with db_open.
+- [DB_GetLegacyDBResult](DB_GetLegacyDBResult): Get memory handle for an SQLite query that was executed with DB_ExecuteQuery.
+- [DB_GetDatabaseConnectionCount](DB_GetDatabaseConnectionCount): The function gets the number of open database connections for debugging purposes.
+- [DB_GetDatabaseResultSetCount](DB_GetDatabaseResultSetCount): The function gets the number of open database results.

--- a/docs/scripting/functions/DB_GetFieldName.md
+++ b/docs/scripting/functions/DB_GetFieldName.md
@@ -1,0 +1,114 @@
+---
+title: DB_GetFieldName
+description: Returns the name of the field at the specified index.
+keywords:
+  - sqlite
+tags: ["sqlite"]
+---
+
+## Description
+
+Returns the name of a field at a particular index.
+
+| Name            | Description                                                                      |
+|-----------------|----------------------------------------------------------------------------------|
+| DBResult:result | The result to get the data from; returned by [DB_ExecuteQuery](DB_ExecuteQuery). |
+| field           | The index of the field to get the name of.                                       |
+| output[]        | The result.                                                                      |
+| size            | The max length of the field.                                                     |
+
+## Returns
+
+Returns 1 if result set handle is valid, otherwise 0.
+
+## Examples
+
+```c
+static DB:gDBConnectionHandle;
+
+public OnGameModeInit()
+{
+    // ...
+
+    // Create a connection to a database
+    gDBConnectionHandle = DB_Open("example.db");
+
+    // If connection to the database exists
+    if (gDBConnectionHandle)
+    {
+        // Select first entry in table "join_log"
+        new DBResult:db_result_set = DB_ExecuteQuery(g_DBConnection, "SELECT * FROM `join_log` LIMIT 1");
+
+        // If result set handle is valid
+        if (db_result_set)
+        {
+            // Get the number of fields from result set
+            new columns = DB_GetRowCount(db_result_set);
+
+            // Allocate some memory for storing field names
+            new field_name[32];
+
+            // Iterate through all column indices
+            for (new column_index; index < column_index; index++)
+            {
+                // Store the name of the i indexed column name into "field_name"
+                DB_GetFieldName(db_result_set, index, field_name, sizeof field_name);
+
+                // Print "field_name"
+                printf("Field name at index %d: \"%s\"", index, field_name);
+            }
+
+            // Frees the result set
+            DB_FreeResultSet(db_result_set);
+        }
+    }
+    else
+    {
+        // Failed to create a connection to the database
+        print("Failed to open a connection to database \"example.db\".");
+    }
+}
+
+public OnGameModeExit()
+{
+    // Close the connection to the database if connection is open
+    if (DB_Close(gDBConnectionHandle))
+    {
+        // Extra cleanup
+        gDBConnectionHandle = DB:0;
+    }
+
+    // ...
+
+    return 1;
+}
+```
+
+## Notes
+
+:::warning
+
+Using an invalid handle other than zero will crash your server! Get a valid database connection handle by using [DB_ExecuteQuery](DB_ExecuteQuery).
+
+:::
+
+## Related Functions
+
+- [DB_Open](DB_Open): Open a connection to an SQLite database
+- [DB_Close](DB_Close): Close the connection to an SQLite database
+- [DB_ExecuteQuery](DB_ExecuteQuery): Query an SQLite database
+- [DB_FreeResultSet](DB_FreeResultSet): Free result memory from a DB_ExecuteQuery
+- [DB_GetRowCount](DB_GetRowCount): Get the number of rows in a result
+- [DB_SelectNextRow](DB_SelectNextRow): Move to the next row
+- [DB_GetFieldCount](DB_GetFieldCount): Get the number of fields in a result
+- [DB_GetFieldName](DB_GetFieldName): Returns the name of a field at a particular index
+- [DB_GetFieldString](DB_GetFieldString): Get content of field with specified ID from current result row
+- [DB_GetFieldStringByName](DB_GetFieldStringByName): Get content of field with specified name from current result row
+- [DB_GetFieldInt](DB_GetFieldInt): Get content of field as an integer with specified ID from current result row
+- [DB_GetFieldIntByName](DB_GetFieldIntByName): Get content of field as an integer with specified name from current result row
+- [DB_GetFieldFloat](DB_GetFieldFloat): Get content of field as a float with specified ID from current result row
+- [DB_GetFieldFloatByName](DB_GetFieldFloatByName): Get content of field as a float with specified name from current result row
+- [DB_GetMemHandle](DB_GetMemHandle): Get memory handle for an SQLite database that was opened with db_open.
+- [DB_GetLegacyDBResult](DB_GetLegacyDBResult): Get memory handle for an SQLite query that was executed with DB_ExecuteQuery.
+- [DB_GetDatabaseConnectionCount](DB_GetDatabaseConnectionCount): The function gets the number of open database connections for debugging purposes.
+- [DB_GetDatabaseResultSetCount](DB_GetDatabaseResultSetCount): The function gets the number of open database results.

--- a/docs/scripting/functions/DB_GetFieldString.md
+++ b/docs/scripting/functions/DB_GetFieldString.md
@@ -1,0 +1,176 @@
+---
+title: DB_GetFieldString
+description: Get the content of a field from DB_ExecuteQuery.
+keywords:
+  - sqlite
+tags: ["sqlite"]
+---
+
+## Description
+
+Get the content of a field from DB_ExecuteQuery
+
+| Name            | Description                      |
+|-----------------|----------------------------------|
+| DBResult:result | The result to get the data from. |
+| field           | The field to get the data from.  |
+| output[]        | The result.                      |
+| size            | The max length of the field.     |
+
+## Returns
+
+Returns 1 if result set handle is valid and the column is available, otherwise 0.
+
+## Example
+
+```c
+// examples.inc
+
+// ...
+
+static FindFieldIndexByName(DBResult:dbResultSet, const fieldName[])
+{
+    // Return value variable with default return value
+    new ret = -1;
+
+    // Field count
+    new field_count = DB_GetFieldCount(dbResultSet);
+
+    // Current field name
+    new current_field_name[32];
+
+    // Iterate through all fields
+    for (new field_index; field_index < field_count; field_index++)
+    {
+        // Get field name
+        if (DB_GetFieldName(dbResultSet, field_index, current_field_name, sizeof current_field_name))
+        {
+            // Compare searched field name to current field name
+            if (!strcmp(fieldName, current_field_name))
+            {
+                // Success, store field index to return value variable
+                ret = field_index;
+
+                // Break out of the loop
+                break;
+            }
+        }
+    }
+
+    // Return found field index or "-1"
+    return ret;
+}
+
+Examples_ListNames(DB:dbConnectionHandle)
+{
+    // Database result set
+    new DBResult:db_result_set = DB_ExecuteQuery("SELECT `name` FROM `examples`");
+
+    // If database result set is valid
+    if (db_result_set)
+    {
+        // Get target field index
+        new target_field_index = FindFieldIndexByName(db_result_set, "name");
+
+        // Check if field index is valid
+        if (target_field_index >= 0)
+        {
+            // Allocate some memory to store results
+            new result[256];
+
+            // Do operations
+            do
+            {
+                // Add value from "example" field to the return value variable
+                DB_GetFieldString(db_result_set, target_field_index, result, sizeof result);
+            }
+
+            // While next row could be fetched
+            while (DB_SelectNextRow(db_result_set));
+        }
+
+        // Free result set
+        DB_FreeResultSet(db_result_set);
+    }
+}
+```
+
+```c
+// mode.pwn
+
+// ...
+
+#include <examples>
+
+static DB:gDBConnectionHandle;
+
+// ...
+
+public OnGameModeInit()
+{
+    // ...
+
+    // Create a connection to a database
+    gDBConnectionHandle = DB_Open("example.db");
+
+    // If connection to the database exists
+    if (gDBConnectionHandle)
+    {
+        // Successfully created a connection to the database
+        print("Successfully created a connection to database \"example.db\".");
+        Examples_ListNames(gDBConnectionHandle);
+    }
+    else
+    {
+        // Failed to create a connection to the database
+        print("Failed to open a connection to database \"example.db\".");
+    }
+
+    // ...
+
+    return 1;
+}
+
+public OnGameModeExit()
+{
+    // Close the connection to the database if connection is open
+    if (DB_Close(gDBConnectionHandle))
+    {
+        // Extra cleanup
+        gDBConnectionHandle = DB:0;
+    }
+
+    // ...
+
+    return 1;
+}
+```
+
+## Notes
+
+:::warning
+
+Using an invalid handle other than zero will crash your server! Get a valid database connection handle by using [DB_ExecuteQuery](DB_ExecuteQuery).
+
+:::
+
+## Related Functions
+
+- [DB_Open](DB_Open): Open a connection to an SQLite database
+- [DB_Close](DB_Close): Close the connection to an SQLite database
+- [DB_ExecuteQuery](DB_ExecuteQuery): Query an SQLite database
+- [DB_FreeResultSet](DB_FreeResultSet): Free result memory from a DB_ExecuteQuery
+- [DB_GetRowCount](DB_GetRowCount): Get the number of rows in a result
+- [DB_SelectNextRow](DB_SelectNextRow): Move to the next row
+- [DB_GetFieldCount](DB_GetFieldCount): Get the number of fields in a result
+- [DB_GetFieldName](DB_GetFieldName): Returns the name of a field at a particular index
+- [DB_GetFieldString](DB_GetFieldString): Get content of field with specified ID from current result row
+- [DB_GetFieldStringByName](DB_GetFieldStringByName): Get content of field with specified name from current result row
+- [DB_GetFieldInt](DB_GetFieldInt): Get content of field as an integer with specified ID from current result row
+- [DB_GetFieldIntByName](DB_GetFieldIntByName): Get content of field as an integer with specified name from current result row
+- [DB_GetFieldFloat](DB_GetFieldFloat): Get content of field as a float with specified ID from current result row
+- [DB_GetFieldFloatByName](DB_GetFieldFloatByName): Get content of field as a float with specified name from current result row
+- [DB_GetMemHandle](DB_GetMemHandle): Get memory handle for an SQLite database that was opened with db_open.
+- [DB_GetLegacyDBResult](DB_GetLegacyDBResult): Get memory handle for an SQLite query that was executed with DB_ExecuteQuery.
+- [DB_GetDatabaseConnectionCount](DB_GetDatabaseConnectionCount): The function gets the number of open database connections for debugging purposes.
+- [DB_GetDatabaseResultSetCount](DB_GetDatabaseResultSetCount): The function gets the number of open database results.

--- a/docs/scripting/functions/DB_GetFieldStringByName.md
+++ b/docs/scripting/functions/DB_GetFieldStringByName.md
@@ -1,0 +1,136 @@
+---
+title: DB_GetFieldStringByName
+description: Gets the contents of the field as a string with the specified field name.
+keywords:
+  - sqlite
+tags: ["sqlite"]
+---
+
+## Description
+
+Get the contents of field with specified name.
+
+| Name            | Description                        |
+|-----------------|------------------------------------|
+| DBResult:result | The result to get the data from    |
+| const field[]   | The fieldname to get the data from |
+| output[]        | The result                         |
+| size            | The max length of the field        |
+
+## Returns
+
+Returns 1 if result set handle is valid and the column is available, otherwise 0.
+
+## Examples
+
+```c
+// examples.inc
+
+// ...
+
+Examples_ListNames(DB:dbConnectionHandle)
+{
+    // Database result set
+    new DBResult:db_result_set = DB_ExecuteQuery("SELECT `name` FROM `examples`");
+
+    // If database result set is valid
+    if (db_result_set)
+    {
+        // Allocate some memory to store results
+        new result[256];
+
+        // Do operations
+        do
+        {
+            // Add value from "example" field to the return value variable
+            DB_GetFieldStringByName(db_result_set, "name", result, sizeof result);
+        }
+
+        // While next row could be fetched
+        while (DB_SelectNextRow(db_result_set));
+
+        // Free result set
+        DB_FreeResultSet(db_result_set);
+    }
+}
+```
+
+```c
+// mode.pwn
+
+// ...
+
+#include <examples>
+
+static DB:gDBConnectionHandle;
+
+// ...
+
+public OnGameModeInit()
+{
+    // ...
+
+    // Create a connection to a database
+    gDBConnectionHandle = DB_Open("example.db");
+
+    // If connection to the database exists
+    if (gDBConnectionHandle)
+    {
+        // Successfully created a connection to the database
+        print("Successfully created a connection to database \"example.db\".");
+        Examples_ListNames(gDBConnectionHandle);
+    }
+    else
+    {
+        // Failed to create a connection to the database
+        print("Failed to open a connection to database \"example.db\".");
+    }
+
+    // ...
+
+    return 1;
+}
+
+public OnGameModeExit()
+{
+    // Close the connection to the database if connection is open
+    if (DB_Close(gDBConnectionHandle))
+    {
+        // Extra cleanup
+        gDBConnectionHandle = DB:0;
+    }
+
+    // ...
+
+    return 1;
+}
+```
+
+## Notes
+
+:::warning
+
+Using an invalid handle other than zero will crash your server! Get a valid database connection handle by using [DB_ExecuteQuery](DB_ExecuteQuery).
+
+:::
+
+## Related Functions
+
+- [DB_Open](DB_Open): Open a connection to an SQLite database
+- [DB_Close](DB_Close): Close the connection to an SQLite database
+- [DB_ExecuteQuery](DB_ExecuteQuery): Query an SQLite database
+- [DB_FreeResultSet](DB_FreeResultSet): Free result memory from a DB_ExecuteQuery
+- [DB_GetRowCount](DB_GetRowCount): Get the number of rows in a result
+- [DB_SelectNextRow](DB_SelectNextRow): Move to the next row
+- [DB_GetFieldCount](DB_GetFieldCount): Get the number of fields in a result
+- [DB_GetFieldName](DB_GetFieldName): Returns the name of a field at a particular index
+- [DB_GetFieldString](DB_GetFieldString): Get content of field with specified ID from current result row
+- [DB_GetFieldStringByName](DB_GetFieldStringByName): Get content of field with specified name from current result row
+- [DB_GetFieldInt](DB_GetFieldInt): Get content of field as an integer with specified ID from current result row
+- [DB_GetFieldIntByName](DB_GetFieldIntByName): Get content of field as an integer with specified name from current result row
+- [DB_GetFieldFloat](DB_GetFieldFloat): Get content of field as a float with specified ID from current result row
+- [DB_GetFieldFloatByName](DB_GetFieldFloatByName): Get content of field as a float with specified name from current result row
+- [DB_GetMemHandle](DB_GetMemHandle): Get memory handle for an SQLite database that was opened with db_open.
+- [DB_GetLegacyDBResult](DB_GetLegacyDBResult): Get memory handle for an SQLite query that was executed with DB_ExecuteQuery.
+- [DB_GetDatabaseConnectionCount](DB_GetDatabaseConnectionCount): The function gets the number of open database connections for debugging purposes.
+- [DB_GetDatabaseResultSetCount](DB_GetDatabaseResultSetCount): The function gets the number of open database results.

--- a/docs/scripting/functions/DB_GetLegacyDBResult.md
+++ b/docs/scripting/functions/DB_GetLegacyDBResult.md
@@ -1,0 +1,100 @@
+---
+title: DB_GetLegacyDBResult
+description: Gets the memory handle for a SQLite database result set that was allocated with `DB_ExecuteQuery`.
+keywords:
+  - sqlite
+tags: ["sqlite"]
+---
+
+## Description
+
+The function gets the memory handle for a SQLite database result set that was allocated with [DB_ExecuteQuery](DB_ExecuteQuery).
+
+| Name            | Description                                                              |
+|-----------------|--------------------------------------------------------------------------|
+| DBResult:result | The index of the query (returned by [DB_ExecuteQuery](DB_ExecuteQuery)). |
+
+## Returns
+
+Returns the memory handle of the database result set handle.
+
+## Examples
+
+```c
+static DB:gDBConnectionHandle;
+
+// ...
+
+public OnGameModeInit()
+{
+    // ...
+
+    // Create a connection to a database
+    gDBConnectionHandle = DB_Open("example.db");
+
+    // If connection to the database exists
+    if (gDBConnectionHandle)
+    {
+        // Successfully created a connection to the database
+        new DBResult:result_set = DB_ExecuteQuery("SELECT * FROM `examples`");
+        print("Successfully created a connection to database \"example.db\".");
+        if (result_set)
+        {
+            printf("Database connection memory handle: 0x%x", DB_GetLegacyDBResult(result_set));
+            DB_FreeResultSet(result_set);
+        }
+    }
+    else
+    {
+        // Failed to create a connection to the database
+        print("Failed to open a connection to database \"example.db\".");
+    }
+
+    // ...
+
+    return 1;
+}
+
+public OnGameModeExit()
+{
+    // Close the connection to the database if connection is open
+    if (DB_Close(gDBConnectionHandle))
+    {
+        // Extra cleanup
+        gDBConnectionHandle = DB:0;
+    }
+
+    // ...
+
+    return 1;
+}
+```
+
+## Notes
+
+:::warning
+
+Using an invalid handle other than zero will crash your server! Get a valid database connection handle by using [DB_ExecuteQuery](DB_ExecuteQuery).
+
+:::
+
+## Related Functions
+
+- [DB_Open](DB_Open): Open a connection to an SQLite database
+- [DB_Close](DB_Close): Close the connection to an SQLite database
+- [DB_ExecuteQuery](DB_ExecuteQuery): Query an SQLite database
+- [DB_FreeResultSet](DB_FreeResultSet): Free result memory from a DB_ExecuteQuery
+- [DB_GetRowCount](DB_GetRowCount): Get the number of rows in a result
+- [DB_SelectNextRow](DB_SelectNextRow): Move to the next row
+- [DB_GetFieldCount](DB_GetFieldCount): Get the number of fields in a result
+- [DB_GetFieldName](DB_GetFieldName): Returns the name of a field at a particular index
+- [DB_GetFieldString](DB_GetFieldString): Get content of field with specified ID from current result row
+- [DB_GetFieldStringByName](DB_GetFieldStringByName): Get content of field with specified name from current result row
+- [DB_GetFieldInt](DB_GetFieldInt): Get content of field as an integer with specified ID from current result row
+- [DB_GetFieldIntByName](DB_GetFieldIntByName): Get content of field as an integer with specified name from current result row
+- [DB_GetFieldFloat](DB_GetFieldFloat): Get content of field as a float with specified ID from current result row
+- [DB_GetFieldFloatByName](DB_GetFieldFloatByName): Get content of field as a float with specified name from current result row
+- [DB_GetMemHandle](DB_GetMemHandle): Get memory handle for an SQLite database that was opened with db_open.
+- [DB_GetLegacyDBResult](DB_GetLegacyDBResult): Get memory handle for an SQLite query that was executed with DB_ExecuteQuery.
+- [DB_GetDatabaseConnectionCount](DB_GetDatabaseConnectionCount): The function gets the number of open database connections for debugging purposes.
+- [DB_GetDatabaseResultSetCount](DB_GetDatabaseResultSetCount): The function gets the number of open database results.

--- a/docs/scripting/functions/DB_GetMemHandle.md
+++ b/docs/scripting/functions/DB_GetMemHandle.md
@@ -1,0 +1,95 @@
+---
+title: DB_GetMemHandle
+description: Gets the memory handle for a SQLite database connection that was opened with `DB_Open`.
+keywords:
+  - sqlite
+tags: ["sqlite"]
+---
+
+## Description
+
+The function gets the memory handle for a SQLite database connection that was opened with [DB_Open](DB_Open).
+
+| Name  | Description                                                            |
+|-------|------------------------------------------------------------------------|
+| DB:db | The index of the database connection (returned by [DB_Open](DB_Open)). |
+
+## Returns
+
+Returns the memory handle of the database connection handle.
+
+## Examples
+
+```c
+static DB:gDBConnectionHandle;
+
+// ...
+
+public OnGameModeInit()
+{
+    // ...
+
+    // Create a connection to a database
+    gDBConnectionHandle = DB_Open("example.db");
+
+    // If connection to the database exists
+    if (gDBConnectionHandle)
+    {
+        // Successfully created a connection to the database
+        print("Successfully created a connection to database \"example.db\".");
+        printf("Database connection memory handle: 0x%x", DB_GetMemHandle(gDBConnectionHandle));
+    }
+    else
+    {
+        // Failed to create a connection to the database
+        print("Failed to open a connection to database \"example.db\".");
+    }
+
+    // ...
+
+    return 1;
+}
+
+public OnGameModeExit()
+{
+    // Close the connection to the database if connection is open
+    if (DB_Close(gDBConnectionHandle))
+    {
+        // Extra cleanup
+        gDBConnectionHandle = DB:0;
+    }
+
+    // ...
+
+    return 1;
+}
+```
+
+## Notes
+
+:::warning
+
+Using an invalid handle other than zero will crash your server! Get a valid database connection handle by using [DB_ExecuteQuery](DB_ExecuteQuery).
+
+:::
+
+## Related Functions
+
+- [DB_Open](DB_Open): Open a connection to an SQLite database
+- [DB_Close](DB_Close): Close the connection to an SQLite database
+- [DB_ExecuteQuery](DB_ExecuteQuery): Query an SQLite database
+- [DB_FreeResultSet](DB_FreeResultSet): Free result memory from a DB_ExecuteQuery
+- [DB_GetRowCount](DB_GetRowCount): Get the number of rows in a result
+- [DB_SelectNextRow](DB_SelectNextRow): Move to the next row
+- [DB_GetFieldCount](DB_GetFieldCount): Get the number of fields in a result
+- [DB_GetFieldName](DB_GetFieldName): Returns the name of a field at a particular index
+- [DB_GetFieldString](DB_GetFieldString): Get content of field with specified ID from current result row
+- [DB_GetFieldStringByName](DB_GetFieldStringByName): Get content of field with specified name from current result row
+- [DB_GetFieldInt](DB_GetFieldInt): Get content of field as an integer with specified ID from current result row
+- [DB_GetFieldIntByName](DB_GetFieldIntByName): Get content of field as an integer with specified name from current result row
+- [DB_GetFieldFloat](DB_GetFieldFloat): Get content of field as a float with specified ID from current result row
+- [DB_GetFieldFloatByName](DB_GetFieldFloatByName): Get content of field as a float with specified name from current result row
+- [DB_GetMemHandle](DB_GetMemHandle): Get memory handle for an SQLite database that was opened with DB_Open.
+- [DB_GetLegacyDBResult](DB_GetLegacyDBResult): Get memory handle for an SQLite query that was executed with DB_ExecuteQuery.
+- [DB_GetDatabaseConnectionCount](DB_GetDatabaseConnectionCount): The function gets the number of open database connections for debugging purposes.
+- [DB_GetDatabaseResultSetCount](DB_GetDatabaseResultSetCount): The function gets the number of open database results.

--- a/docs/scripting/functions/DB_GetRowCount.md
+++ b/docs/scripting/functions/DB_GetRowCount.md
@@ -1,0 +1,133 @@
+---
+title: DB_GetRowCount
+description: Returns the number of rows from a DB_ExecuteQuery.
+keywords:
+  - sqlite
+tags: ["sqlite"]
+---
+
+## Description
+
+Returns the number of rows from a DB_ExecuteQuery
+
+| Name              | Description                                      |
+|-------------------|--------------------------------------------------|
+| DBResult:dbresult | The result of [DB_ExecuteQuery](DB_ExecuteQuery) |
+
+## Returns
+
+The number of rows in the result.
+
+## Examples
+
+```c
+// examples.inc
+
+// ...
+
+Examples_ListNames(DB:dbConnectionHandle)
+{
+    // Database result set
+    new DBResult:db_result_set = DB_ExecuteQuery("SELECT `name` FROM `examples`");
+
+    // If database result set is valid
+    if (db_result_set)
+    {
+        // Allocate some memory to store results
+        new result[256];
+
+        // Do operations
+        do
+        {
+            // Add value from "example" field to the return value variable
+            DB_GetFieldStringByName(db_result_set, "name", result, sizeof result);
+        }
+
+        // While next row could be fetched
+        while (DB_SelectNextRow(db_result_set));
+
+        // Free result set
+        DB_FreeResultSet(db_result_set);
+    }
+}
+```
+
+```c
+// mode.pwn
+
+// ...
+
+#include <examples>
+
+static DB:gDBConnectionHandle;
+
+// ...
+
+public OnGameModeInit()
+{
+    // ...
+
+    // Create a connection to a database
+    gDBConnectionHandle = DB_Open("example.db");
+
+    // If connection to the database exists
+    if (gDBConnectionHandle)
+    {
+        // Successfully created a connection to the database
+        print("Successfully created a connection to database \"example.db\".");
+        Examples_ListNames(gDBConnectionHandle);
+    }
+    else
+    {
+        // Failed to create a connection to the database
+        print("Failed to open a connection to database \"example.db\".");
+    }
+
+    // ...
+
+    return 1;
+}
+
+public OnGameModeExit()
+{
+    // Close the connection to the database if connection is open
+    if (DB_Close(gDBConnectionHandle))
+    {
+        // Extra cleanup
+        gDBConnectionHandle = DB:0;
+    }
+
+    // ...
+
+    return 1;
+}
+```
+
+## Notes
+
+:::warning
+
+Using an invalid handle other than zero will crash your server! Get a valid database connection handle by using [DB_ExecuteQuery](DB_ExecuteQuery).
+
+:::
+
+## Related Functions
+
+- [DB_Open](DB_Open): Open a connection to an SQLite database
+- [DB_Close](DB_Close): Close the connection to an SQLite database
+- [DB_ExecuteQuery](DB_ExecuteQuery): Query an SQLite database
+- [DB_FreeResultSet](DB_FreeResultSet): Free result memory from a DB_ExecuteQuery
+- [DB_GetRowCount](DB_GetRowCount): Get the number of rows in a result
+- [DB_SelectNextRow](DB_SelectNextRow): Move to the next row
+- [DB_GetFieldCount](DB_GetFieldCount): Get the number of fields in a result
+- [DB_GetFieldName](DB_GetFieldName): Returns the name of a field at a particular index
+- [DB_GetFieldString](DB_GetFieldString): Get content of field with specified ID from current result row
+- [DB_GetFieldStringByName](DB_GetFieldStringByName): Get content of field with specified name from current result row
+- [DB_GetFieldInt](DB_GetFieldInt): Get content of field as an integer with specified ID from current result row
+- [DB_GetFieldIntByName](DB_GetFieldIntByName): Get content of field as an integer with specified name from current result row
+- [DB_GetFieldFloat](DB_GetFieldFloat): Get content of field as a float with specified ID from current result row
+- [DB_GetFieldFloatByName](DB_GetFieldFloatByName): Get content of field as a float with specified name from current result row
+- [DB_GetMemHandle](DB_GetMemHandle): Get memory handle for an SQLite database that was opened with db_open.
+- [DB_GetLegacyDBResult](DB_GetLegacyDBResult): Get memory handle for an SQLite query that was executed with DB_ExecuteQuery.
+- [DB_GetDatabaseConnectionCount](DB_GetDatabaseConnectionCount): The function gets the number of open database connections for debugging purposes.
+- [DB_GetDatabaseResultSetCount](DB_GetDatabaseResultSetCount): The function gets the number of open database results.

--- a/docs/scripting/functions/DB_SelectNextRow.md
+++ b/docs/scripting/functions/DB_SelectNextRow.md
@@ -1,0 +1,133 @@
+---
+title: DB_SelectNextRow
+description: Moves to the next row of the result set allocated with `DB_ExecuteQuery`.
+keywords:
+  - sqlite
+tags: ["sqlite"]
+---
+
+## Description
+
+The function moves to the next row of the result set allocated with [DB_ExecuteQuery](DB_ExecuteQuery).
+
+| Name              | Description                                       |
+|-------------------|---------------------------------------------------|
+| DBResult:dbresult | The result of [DB_ExecuteQuery](DB_ExecuteQuery). |
+
+## Returns
+
+Returns 1 if result set handle is valid and the last row is not reached yet, otherwise 0.
+
+## Examples
+
+```c
+// examples.inc
+
+// ...
+
+Examples_ListNames(DB:dbConnectionHandle)
+{
+    // Database result set
+    new DBResult:db_result_set = DB_ExecuteQuery("SELECT `name` FROM `examples`");
+
+    // If database result set is valid
+    if (db_result_set)
+    {
+        // Allocate some memory to store results
+        new result[256];
+
+        // Do operations
+        do
+        {
+            // Add value from "example" field to the return value variable
+            DB_GetFieldStringByName(db_result_set, "name", result, sizeof result);
+        }
+
+        // While next row could be fetched
+        while (DB_SelectNextRow(db_result_set));
+
+        // Free result set
+        DB_FreeResultSet(db_result_set);
+    }
+}
+```
+
+```c
+// mode.pwn
+
+// ...
+
+#include <examples>
+
+static DB:gDBConnectionHandle;
+
+// ...
+
+public OnGameModeInit()
+{
+    // ...
+
+    // Create a connection to a database
+    gDBConnectionHandle = DB_Open("example.db");
+
+    // If connection to the database exists
+    if (gDBConnectionHandle)
+    {
+        // Successfully created a connection to the database
+        print("Successfully created a connection to database \"example.db\".");
+        Examples_ListNames(gDBConnectionHandle);
+    }
+    else
+    {
+        // Failed to create a connection to the database
+        print("Failed to open a connection to database \"example.db\".");
+    }
+
+    // ...
+
+    return 1;
+}
+
+public OnGameModeExit()
+{
+    // Close the connection to the database if connection is open
+    if (DB_Close(gDBConnectionHandle))
+    {
+        // Extra cleanup
+        gDBConnectionHandle = DB:0;
+    }
+
+    // ...
+
+    return 1;
+}
+```
+
+## Notes
+
+:::warning
+
+Using an invalid handle other than zero will crash your server! Get a valid database connection handle by using [DB_ExecuteQuery](DB_ExecuteQuery).
+
+:::
+
+## Related Functions
+
+- [DB_Open](DB_Open): Open a connection to an SQLite database
+- [DB_Close](DB_Close): Close the connection to an SQLite database
+- [DB_ExecuteQuery](DB_ExecuteQuery): Query an SQLite database
+- [DB_FreeResultSet](DB_FreeResultSet): Free result memory from a DB_ExecuteQuery
+- [DB_GetRowCount](DB_GetRowCount): Get the number of rows in a result
+- [DB_SelectNextRow](DB_SelectNextRow): Move to the next row
+- [DB_GetFieldCount](DB_GetFieldCount): Get the number of fields in a result
+- [DB_GetFieldName](DB_GetFieldName): Returns the name of a field at a particular index
+- [DB_GetFieldString](DB_GetFieldString): Get content of field with specified ID from current result row
+- [DB_GetFieldStringByName](DB_GetFieldStringByName): Get content of field with specified name from current result row
+- [DB_GetFieldInt](DB_GetFieldInt): Get content of field as an integer with specified ID from current result row
+- [DB_GetFieldIntByName](DB_GetFieldIntByName): Get content of field as an integer with specified name from current result row
+- [DB_GetFieldFloat](DB_GetFieldFloat): Get content of field as a float with specified ID from current result row
+- [DB_GetFieldFloatByName](DB_GetFieldFloatByName): Get content of field as a float with specified name from current result row
+- [DB_GetMemHandle](DB_GetMemHandle): Get memory handle for an SQLite database that was opened with db_open.
+- [DB_GetLegacyDBResult](DB_GetLegacyDBResult): Get memory handle for an SQLite query that was executed with DB_ExecuteQuery.
+- [DB_GetDatabaseConnectionCount](DB_GetDatabaseConnectionCount): The function gets the number of open database connections for debugging purposes.
+- [DB_GetDatabaseResultSetCount](DB_GetDatabaseResultSetCount): The function gets the number of open database results.

--- a/docs/scripting/functions/db_close.md
+++ b/docs/scripting/functions/db_close.md
@@ -3,6 +3,7 @@ title: db_close
 description: Closes a SQLite database connection that was opened with `db_open`.
 keywords:
   - sqlite
+tags: ["sqlite"]
 ---
 
 <LowercaseNote />

--- a/docs/scripting/functions/db_close.md
+++ b/docs/scripting/functions/db_close.md
@@ -79,6 +79,7 @@ Using an invalid handle other than zero will crash your server! Get a valid data
 ## Related Functions
 
 - [db_open](db_open): Open a connection to an SQLite database
+- [db_close](db_close): Close the connection to an SQLite database
 - [db_query](db_query): Query an SQLite database
 - [db_free_result](db_free_result): Free result memory from a db_query
 - [db_num_rows](db_num_rows): Get the number of rows in a result
@@ -95,3 +96,24 @@ Using an invalid handle other than zero will crash your server! Get a valid data
 - [db_get_result_mem_handle](db_get_result_mem_handle): Get memory handle for an SQLite query that was executed with db_query.
 - [db_debug_openfiles](db_debug_openfiles): The function gets the number of open database connections for debugging purposes.
 - [db_debug_openresults](db_debug_openresults): The function gets the number of open database results.
+
+## Modern SQLite Functions
+
+- [DB_Open](DB_Open): Open a connection to an SQLite database
+- [DB_Close](DB_Close): Close the connection to an SQLite database
+- [DB_ExecuteQuery](DB_ExecuteQuery): Query an SQLite database
+- [DB_FreeResultSet](DB_FreeResultSet): Free result memory from a DB_ExecuteQuery
+- [DB_GetRowCount](DB_GetRowCount): Get the number of rows in a result
+- [DB_SelectNextRow](DB_SelectNextRow): Move to the next row
+- [DB_GetFieldCount](DB_GetFieldCount): Get the number of fields in a result
+- [DB_GetFieldName](DB_GetFieldName): Returns the name of a field at a particular index
+- [DB_GetFieldString](DB_GetFieldString): Get content of field with specified ID from current result row
+- [DB_GetFieldStringByName](DB_GetFieldStringByName): Get content of field with specified name from current result row
+- [DB_GetFieldInt](DB_GetFieldInt): Get content of field as an integer with specified ID from current result row
+- [DB_GetFieldIntByName](DB_GetFieldIntByName): Get content of field as an integer with specified name from current result row
+- [DB_GetFieldFloat](DB_GetFieldFloat): Get content of field as a float with specified ID from current result row
+- [DB_GetFieldFloatByName](DB_GetFieldFloatByName): Get content of field as a float with specified name from current result row
+- [DB_GetMemHandle](DB_GetMemHandle): Get memory handle for an SQLite database that was opened with db_open.
+- [DB_GetLegacyDBResult](DB_GetLegacyDBResult): Get memory handle for an SQLite query that was executed with DB_ExecuteQuery.
+- [DB_GetDatabaseConnectionCount](DB_GetDatabaseConnectionCount): The function gets the number of open database connections for debugging purposes.
+- [DB_GetDatabaseResultSetCount](DB_GetDatabaseResultSetCount): The function gets the number of open database results.

--- a/docs/scripting/functions/db_open.md
+++ b/docs/scripting/functions/db_open.md
@@ -3,6 +3,7 @@ title: db_open
 description: The function is used to open a connection to a SQLite database file, which is inside the `/scriptfiles` folder.
 keywords:
   - sqlite
+tags: ["sqlite"]
 ---
 
 <LowercaseNote />
@@ -11,9 +12,10 @@ keywords:
 
 The function is used to open a connection to a SQLite database, which is inside the "/scriptfiles" folder.
 
-| Name   | Description               |
-| ------ | ------------------------- |
-| name[] | File name of the database |
+| Name                                                                | Description                                           |
+|---------------------------------------------------------------------|-------------------------------------------------------|
+| const name[]                                                        | File name of the database                             |
+| SQLITE_OPEN:flags = SQLITE_OPEN_READWRITE &#124; SQLITE_OPEN_CREATE | [Permissions / Flags](../resources/sqlite-open-flags) |
 
 ## Returns
 
@@ -92,3 +94,7 @@ It will create a new SQLite database file, if there is no SQLite database file w
 - [db_get_result_mem_handle](db_get_result_mem_handle): Get memory handle for an SQLite query that was executed with db_query.
 - [db_debug_openfiles](db_debug_openfiles): The function gets the number of open database connections for debugging purposes.
 - [db_debug_openresults](db_debug_openresults): The function gets the number of open database results.
+
+## Related Resources
+
+- [SQLite Open Flags](../resources/sqlite-open-flags)

--- a/docs/scripting/functions/db_open.md
+++ b/docs/scripting/functions/db_open.md
@@ -77,6 +77,7 @@ It will create a new SQLite database file, if there is no SQLite database file w
 
 ## Related Functions
 
+- [db_open](db_open): Open a connection to an SQLite database
 - [db_close](db_close): Close the connection to an SQLite database
 - [db_query](db_query): Query an SQLite database
 - [db_free_result](db_free_result): Free result memory from a db_query
@@ -94,6 +95,27 @@ It will create a new SQLite database file, if there is no SQLite database file w
 - [db_get_result_mem_handle](db_get_result_mem_handle): Get memory handle for an SQLite query that was executed with db_query.
 - [db_debug_openfiles](db_debug_openfiles): The function gets the number of open database connections for debugging purposes.
 - [db_debug_openresults](db_debug_openresults): The function gets the number of open database results.
+
+## Modern SQLite Functions
+
+- [DB_Open](DB_Open): Open a connection to an SQLite database
+- [DB_Close](DB_Close): Close the connection to an SQLite database
+- [DB_ExecuteQuery](DB_ExecuteQuery): Query an SQLite database
+- [DB_FreeResultSet](DB_FreeResultSet): Free result memory from a DB_ExecuteQuery
+- [DB_GetRowCount](DB_GetRowCount): Get the number of rows in a result
+- [DB_SelectNextRow](DB_SelectNextRow): Move to the next row
+- [DB_GetFieldCount](DB_GetFieldCount): Get the number of fields in a result
+- [DB_GetFieldName](DB_GetFieldName): Returns the name of a field at a particular index
+- [DB_GetFieldString](DB_GetFieldString): Get content of field with specified ID from current result row
+- [DB_GetFieldStringByName](DB_GetFieldStringByName): Get content of field with specified name from current result row
+- [DB_GetFieldInt](DB_GetFieldInt): Get content of field as an integer with specified ID from current result row
+- [DB_GetFieldIntByName](DB_GetFieldIntByName): Get content of field as an integer with specified name from current result row
+- [DB_GetFieldFloat](DB_GetFieldFloat): Get content of field as a float with specified ID from current result row
+- [DB_GetFieldFloatByName](DB_GetFieldFloatByName): Get content of field as a float with specified name from current result row
+- [DB_GetMemHandle](DB_GetMemHandle): Get memory handle for an SQLite database that was opened with db_open.
+- [DB_GetLegacyDBResult](DB_GetLegacyDBResult): Get memory handle for an SQLite query that was executed with DB_ExecuteQuery.
+- [DB_GetDatabaseConnectionCount](DB_GetDatabaseConnectionCount): The function gets the number of open database connections for debugging purposes.
+- [DB_GetDatabaseResultSetCount](DB_GetDatabaseResultSetCount): The function gets the number of open database results.
 
 ## Related Resources
 

--- a/docs/scripting/resources/sqlite-open-flags.md
+++ b/docs/scripting/resources/sqlite-open-flags.md
@@ -1,0 +1,42 @@
+---
+title: SQLite Open Flags
+description: SQLite open flags definitions.
+---
+
+:::note
+
+These flags are used by [DB_Open](../functions/db_open).
+
+:::
+
+| Definitions               | Description   |
+|---------------------------|---------------|
+| UNKNOWN_SQLITE_OPEN       |               |
+| SQLITE_OPEN_READONLY      |               |
+| SQLITE_OPEN_READWRITE     |               |
+| SQLITE_OPEN_CREATE        |               |
+| SQLITE_OPEN_DELETEONCLOSE | Requires VFS. |
+| SQLITE_OPEN_EXCLUSIVE     | Requires VFS. |
+| SQLITE_OPEN_AUTOPROXY     | Requires VFS. |
+| SQLITE_OPEN_URI           |               |
+| SQLITE_OPEN_MEMORY        |               |
+| SQLITE_OPEN_MAIN_DB       | Requires VFS. |
+| SQLITE_OPEN_TEMP_DB       | Requires VFS. |
+| SQLITE_OPEN_TRANSIENT_DB  | Requires VFS. |
+| SQLITE_OPEN_MAIN_JOURNAL  | Requires VFS. |
+| SQLITE_OPEN_TEMP_JOURNAL  | Requires VFS. |
+| SQLITE_OPEN_SUBJOURNAL    | Requires VFS. |
+| SQLITE_OPEN_SUPER_JOURNAL | Requires VFS. |
+| SQLITE_OPEN_NOMUTEX       |               |
+| SQLITE_OPEN_FULLMUTEX     |               |
+| SQLITE_OPEN_SHAREDCACHE   |               |
+| SQLITE_OPEN_PRIVATECACHE  |               |
+| SQLITE_OPEN_WAL           | Requires VFS. |
+| SQLITE_OPEN_NOFOLLOW      |               |
+| SQLITE_OPEN_EXRESCODE     |               |
+
+:::note
+
+Learn about VFS at https://www.sqlite.org/c3ref/vfs.html
+
+:::


### PR DESCRIPTION
Added these docs:

`DB_ExecuteQuery.md`
`DB_FreeResultSet.md`
`DB_GetDatabaseConnectionCount.md`
`DB_GetDatabaseResultSetCount.md`
`DB_GetFieldCount.md`
`DB_GetFieldFloat.md`
`DB_GetFieldFloatByName.md`
`DB_GetFieldInt.md`
`DB_GetFieldIntByName.md`
`DB_GetFieldName.md`
`DB_GetFieldString.md`
`DB_GetFieldStringByName.md`
`DB_GetLegacyDBResult.md`
`DB_GetMemHandle.md`
`DB_GetRowCount.md`
`DB_SelectNextRow.md`
`resources/sqlite-open-flags.md`

Honestly, I don't know what to do with `db_open` and `db_close`.
If I rename them to "DB_Open" and "DB_Close", old links
https://www.open.mp/docs/scripting/functions/db_open
https://www.open.mp/docs/scripting/functions/db_close
will break because of the case sensitivity.

Related issue: #718