### PR TITLE
Remove samp button

### DIFF
--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -238,11 +238,6 @@ const Home = () => {
                     tooltip="Download open.mp launcher"
                     link={"https://github.com/openmultiplayer/launcher/releases/latest"}
                   />
-                  <DownloadButton
-                    title={"Download SA-MP client"}
-                    tooltip="Download SA-MP client"
-                    link={"https://sa-mp.mp/downloads/"}
-                  />
                   <DocumentationButton />
                 </Flex>
               </HStack>


### PR DESCRIPTION
There's no need for the `Download SA-MP Client` to be in the homepage anymore as omp-launcher already download SA-MP files on its own.