### PR TITLE
Auto pull request labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+# Add 'area:translation' label to any changes within 'docs/translations' folder or any subfolders
+area:translation:
+- changed-files:
+  - any-glob-to-any-file: docs/translations/**

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5


### PR DESCRIPTION
This pull request adds [Labeler](https://github.com/marketplace/actions/labeler) action.

Labeler action adds the `area:translation` label to pull requests that are related to translation docs.