### PR TITLE
Client check doc correction

### DIFF
--- a/docs/scripting/callbacks/OnClientCheckResponse.md
+++ b/docs/scripting/callbacks/OnClientCheckResponse.md
@@ -32,8 +32,7 @@ public OnClientCheckResponse(playerid, actionid, memaddr, retndata)
 {
     if(actionid == 0x48) // or 72
     {
-        print("WARNING: The player doesn't seem to be using a regular computer!");
-        Kick(playerid);
+        print("The player is connecting using the PC client.");
     }
     return 1;
 }

--- a/docs/scripting/functions/SendClientCheck.md
+++ b/docs/scripting/functions/SendClientCheck.md
@@ -35,8 +35,7 @@ public OnClientCheckResponse(playerid, actionid, memaddr, retndata)
 {
     if(actionid == 0x48) // or 72
     {
-        print("WARNING: The player doesn't seem to be using a regular computer!");
-        Kick(playerid);
+        print("The player is connecting using the PC client.");
     }
     return 1;
 }

--- a/docs/translations/fil/scripting/callbacks/OnClientCheckResponse.md
+++ b/docs/translations/fil/scripting/callbacks/OnClientCheckResponse.md
@@ -32,8 +32,7 @@ public OnClientCheckResponse(playerid, actionid, memaddr, retndata)
 {
     if(actionid == 0x48) // or 72
     {
-        print("WARNING: The player doesn't seem to be using a regular computer!");
-        Kick(playerid);
+        print("The player is connecting using the PC client.");
     }
     return 1;
 }

--- a/docs/translations/id/scripting/callbacks/OnClientCheckResponse.md
+++ b/docs/translations/id/scripting/callbacks/OnClientCheckResponse.md
@@ -32,8 +32,7 @@ public OnClientCheckResponse(playerid, actionid, memaddr, retndata)
 {
     if(actionid == 0x48) // or 72
     {
-        print("WARNING: The player doesn't seem to be using a regular computer!");
-        Kick(playerid);
+        print("The player is connecting using the PC client.");
     }
     return 1;
 }


### PR DESCRIPTION
OnClientCheckResponse has a wrong example in the documentation, that made me confused and probably a lot of other people too.

You see, android clients never call OnClientCheckResponse so if it is called. Then it means the player is using a PC, not a "irregular computer".