### PR TITLE
Correct the tip for OnPlayerEnterVehicle

### DIFF
--- a/docs/scripting/callbacks/OnPlayerEnterVehicle.md
+++ b/docs/scripting/callbacks/OnPlayerEnterVehicle.md
@@ -35,7 +35,7 @@ public OnPlayerEnterVehicle(playerid, vehicleid, ispassenger)
 :::tip
 
 - This callback is called when a player BEGINS to enter a vehicle, not when they HAVE entered it. See [OnPlayerStateChange](OnPlayerStateChange).
-- This callback is still called if the player is denied entry to the vehicle (e.g. it is locked or full).
+- This callback is still called if the player is denied entry to a vehicle (e.g. it is locked or full) but only as a passenger.
 
 :::
 


### PR DESCRIPTION
This callback doesn't get called if a player can't get inside a vehicle as a driver due to it being locked. Tested on both, open.mp and SA:MP.
Noted by @tubbsfrommiamivice