### PR TITLE
Update SetPlayerAttachedObject.md

### DIFF
--- a/docs/scripting/functions/SetPlayerAttachedObject.md
+++ b/docs/scripting/functions/SetPlayerAttachedObject.md
@@ -54,7 +54,7 @@ This function is separate from the CreateObject / CreatePlayerObject pools.
 
 :::warning
 
-Atleast 10 objects can be attached to a single player (index 0-9)
+Up to 10 objects can be attached to a single player (index 0-9)
 
 :::
 


### PR DESCRIPTION
Docs: corrected maximum attached object limit description (index 0-9)