### PR TITLE
Fix directory index page handling and locale fallback behavior

### DIFF
--- a/frontend/src/pages/docs/[[...path]].tsx
+++ b/frontend/src/pages/docs/[[...path]].tsx
@@ -12,6 +12,7 @@ import components from "src/components/templates";
 import { hydrate } from "src/mdx-helpers/csr";
 import { DocsSidebar } from "src/components/Sidebar";
 import Admonition from "src/components/Admonition";
+import { useRouter } from 'next/router';
 
 type Props = {
   source?: any;
@@ -19,10 +20,13 @@ type Props = {
   data?: { [key: string]: any };
   fallback?: boolean;
   ghUrl?: string;
+  locale?: string;
 };
 
 const Page = (props: Props) => {
   const [isMounted, setIsMounted] = useState(false);
+  const router = useRouter();
+  const { locale } = router;
 
   // hydrate contains hook calls, and hooks must always be called
   // unconditionally. Because they are called from a regular function here and
@@ -53,7 +57,7 @@ const Page = (props: Props) => {
     );
   }
 
-  const contributeCallToAction = props.fallback ? (
+  const contributeCallToAction = props.fallback && locale !== 'en' ? (
     <Admonition type="warning" title="Not Translated">
       <p>
         This page has not been translated into the language that your browser
@@ -210,6 +214,7 @@ export async function getStaticProps(
       data,
       fallback: result.fallback,
       ghUrl: getDocsGithubUrl(path, !result.fallback, locale),
+      locale,
     },
   };
 }
@@ -247,14 +252,25 @@ export async function getStaticPaths(
     // Filter out translations directory - these are handled separately
     filter((v: string) => v.indexOf("translations") === -1),
 
-    // Filter out category content pages
-    filter((v: string) => !v.endsWith("_.md")),
+    // Handle both regular files and _.md files for directories
+    map((v: string) => {
+      // If it's a directory, keep it!
+      if (statSync(v).isDirectory()) {
+        return v;
+      }
+
+      // If it's _.md, return its directory path
+      if (v.endsWith("_.md")) {
+        return v.slice(0, -4); // this removes "_.md"
+      }
+      return v;
+    }),
 
     // Chop off the `../docs/` base path
     map((v: string) => v.replace("../docs/", "")),
 
     // Chop off the file extension
-    map((v: string) => v.slice(0, v.length - extname(v).length)),
+    map((v: string) => v.endsWith(".md") ? v.slice(0, v.length - extname(v).length) : v),
 
     // slices off "index" from pages so they lead to the base path
     map((v: string) => (v.endsWith("index") ? v.slice(0, v.length - 5) : v)),
@@ -265,7 +281,7 @@ export async function getStaticPaths(
     // Transform the paths into Path objects for "en" locale
     map((v: string) => ({
       params: {
-        path: v.split("/"),
+        path: v.split("/").filter(Boolean),
       },
       locale: "en",
     }))

--- a/frontend/src/utils/content.ts
+++ b/frontend/src/utils/content.ts
@@ -143,12 +143,27 @@ const readLocaleDocsDevMode = async (
   // a special file named `_.md`.
   const dir = "../docs/" + name;
   if (exists(dir) && statSync(dir).isDirectory()) {
-    const list = readdirSync(dir);
-
-    // Attempt to read a file named _.md from the directory
-    let source = await readMdFromLocal(dir + "/_");
-    if (source === undefined) {
-      source = "# " + name + "\n\n";
+    let list = readdirSync(dir);
+    let source;
+  
+    // Fisrt handle locale-specific directory
+    if (locale && locale !== 'en') {
+      const localeDir = `../docs/translations/${locale}/${name}`;
+      const localeIndex = `../docs/translations/${locale}/${name}/_`;
+      
+      if (exists(localeDir) && statSync(localeDir).isDirectory()) {
+        list = readdirSync(localeDir);
+        // read localized _.md first
+        source = await readMdFromLocal(localeIndex);
+      }
+    }
+  
+    // localized content was not found, fall back to eng
+    if (!source) {
+      source = await readMdFromLocal(dir + "/_");
+      if (source === undefined) {
+        source = "# " + name + "\n\n";
+      }
     }
 
     // Generate some content for this category page. A heading, some content
@@ -162,7 +177,7 @@ const readLocaleDocsDevMode = async (
 
     return {
       source: source + additional,
-      fallback: false,
+      fallback: !source || locale === 'en',
     };
   }
 


### PR DESCRIPTION
This PR addresses two issues:
 - 500 errors when accessing directory index pages (_.md) in non-English locales.
 - When viewing wiki pages in English, the fallback warning message was shown.

What i changed:
 - Modified path handling to include index files (_.md) on directories.
 - Made the fallback warning message locale-aware.
 
#### Path Generation:
```ts
// Before
filter((v: string) => !v.endsWith("_.md")),

// After
map((v: string) => {
  if (statSync(v).isDirectory()) {
    return v;
  }
  if (v.endsWith("_.md")) {
    return v.slice(0, -4); // Remove "_.md"
  }
  return v;
}),
```
#### Locale Handling:
```ts
import { useRouter } from 'next/router';

const Page = (props: Props) => {
  const router = useRouter();
  const { locale } = router;

  const contributeCallToAction = props.fallback && locale !== 'en' ? (
    <Admonition type="warning" title="Not Translated">
      // Translation needed message
    </Admonition>
  ) : (
    <Admonition type="note" title="Help Needed">
      // Regular contribution message
    </Admonition>
  );
  // ...
```

### Testing
- [x] Tested directory navigation in English locale
- [x] Tested directory navigation in `pt-BR` and `de` locale
- [x] Verify fallback warning message appears only for untranslated content and not on `en` content
- [x] Tested on both Windows and Linux (WSL2) environments

### Screenshots
The screenshots were taken while the project was deployed on WSL2
![Screenshot 2025-02-08 192022](https://github.com/user-attachments/assets/9fd1121a-e968-4954-8846-df2ac72be277)
![Screenshot 2025-02-08 192324](https://github.com/user-attachments/assets/9a148de5-94eb-4f43-baa1-80678d283370)
![Screenshot 2025-02-08 192518](https://github.com/user-attachments/assets/9db40d75-d03e-4b48-925d-daf383268f86)
![Screenshot 2025-02-08 192559](https://github.com/user-attachments/assets/d8bf93ab-c406-44b6-abd4-4aeae73a19b7)