### PR TITLE
Remove inactive PT-BR CodeOwners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 *                                                                               @openmultiplayer/web
-/docs/translations/pt-BR/                                                       @iPollo @ArTDsL @pushline
+/docs/translations/pt-BR/                                                       @pushline @itsneufox
 /docs/translations/id/                                                          @rsetiawan7 @SanityZeroPercent @flxzor
 /docs/translations/bs/                                                          @NermanLegacy @daddyDOT @GalardoDev
 /docs/translations/sr/                                                          @Trysha-rbrn


### PR DESCRIPTION
I removed iPollo and ArTDsL since they aren't active anymore.

Added myself and kept pushline.

This will make reviewing far easier than waiting for someone that is not active to review.