### PR TITLE
Fix title link hash showing incorrectly

### DIFF
--- a/frontend/src/css/custom.css
+++ b/frontend/src/css/custom.css
@@ -736,3 +736,7 @@ html[data-theme="dark"] {
     padding: 0.5rem;
   }
 }
+
+.hash-link {
+  font-family: var(--ifm-font-family-base);
+}


### PR DESCRIPTION
The button to link the hovered title on a page was shoing as `Nº` incorrectly,  this PR makes it `#`

Old:
![image](https://github.com/user-attachments/assets/94dd5b08-32c1-4b55-a855-f00cbfb4fbea)

New:
![image](https://github.com/user-attachments/assets/e706e6d9-42e7-44ca-9041-59fa93f729ec)

Maybe we should make this a chain again? 