### PR TITLE
fix HTML minifier diagnostic error `hello world` in Greek

### DIFF
--- a/frontend/docs/scripting/language/reference/12-Assorted-tips.md
+++ b/frontend/docs/scripting/language/reference/12-Assorted-tips.md
@@ -138,7 +138,7 @@ Listing: “hello world” in Greek
 ```c
 
 main()
-    printf "˙  ˙\n"
+    printf "Γειάσου κόσμος\n"
 
 ```
 

--- a/frontend/i18n/fa/docusaurus-plugin-content-docs/current/scripting/language/reference/12-Assorted-tips.md
+++ b/frontend/i18n/fa/docusaurus-plugin-content-docs/current/scripting/language/reference/12-Assorted-tips.md
@@ -137,7 +137,7 @@ strupper(string[])
 ```c
 
 main()
-    printf "˙  ˙\n"
+    printf "Γειάσου κόσμος\n"
 
 ```
 

--- a/frontend/i18n/pt-BR/docusaurus-plugin-content-docs/current/scripting/language/reference/04-Functions.md
+++ b/frontend/i18n/pt-BR/docusaurus-plugin-content-docs/current/scripting/language/reference/04-Functions.md
@@ -173,7 +173,8 @@ expression, the function will get executed in that statement/expression.
 The statement that refers to the function is the “caller” and the function itself,
 at that point, is the “callee”: the one being called.
 
-The standard syntax for calling a function is to write the  
+The standard syntax for calling a function is to write the
+
 ### • Chamando funções
 
 Para chamar uma função, escreva o nome seguido da lista de parâmetros entre parênteses. Mesmo que não haja argumentos, os parênteses permanecem. O exemplo below mostra como chamar `power`:
@@ -620,8 +621,9 @@ Programas standalone precisam ter `main` (sem parâmetros), ponto de partida da 
 
 Bibliotecas não exigem `main`, mas devem possuir pelo menos uma função pública. `main` é o entry point primário; funções `public` fornecem pontos alternativos. A VM pode iniciar por uma função pública e, em bibliotecas, `main` pode servir para inicializações.
 
-Para declarar uma função pública, prefixe o nome com `public`. Exemplo: um editor de texto poderia chamar `onkey` a cada tecla digitada para que o script modifique/rejeite caracteres.
-Latin-1 character set) by the “hard space” code in the ANSI character table:
+Para declarar uma função pública, prefixe o nome com `public`. Exemplo: um editor de texto poderia chamar `onkey` a cada tecla digitada para que o script modifique/rejeite caracteres. A função
+onkey abaixo substituiria cada caractere “~” (código 126 no conjunto
+de caracteres ISO Latin‑1) pelo código de “espaço duro” na tabela ANSI:
 
 Listing: onkey function
 
@@ -1082,9 +1084,13 @@ parser will attempt to use the user-defined operator rather than the default
 `User-defined operators: 86`
 
 ---
+
 ### • Call by Value and Call by Reference
+
 In Pawn, function arguments can be passed in two ways: by value and by reference.
+
 #### Call by value
+
 In this method, the value of the variable is passed to the function. A copy of the variable is created and the function operates on the copy, not the original variable. Any changes made to the variable inside the function do not affect the original variable.
 
 ```c
@@ -1101,14 +1107,18 @@ main(){
 	printf("The value of x is %d and value of y is %d, after calling 'swap'.", x, y);
 }
 ```
+
 Output
+
 ```
 The value of x is 10 and value of y is 20, before calling 'swap'.
 The value of x is 10 and value of y is 20, after calling 'swap'.
 ```
 
 #### Call by reference
+
 In this method, the address of the variable is passed to the function. The function operates on the original variable and any changes made to the variable inside the function are reflected in the original variable.
+
 ```c
 swap(&a, &b){
 	new c = a;
@@ -1123,19 +1133,28 @@ main(){
 	printf("The value of x is %d and value of y is %d, after calling 'swap'.", x, y);
 }
 ```
+
 Output
+
 ```
 The value of x is 10 and value of y is 20, before calling 'swap'.
 The value of x is 20 and value of y is 10, after calling 'swap'.
 ```
 
 ### • Recursion / Function Recursion
+
 Recursion in programming refers to the process of a function calling itself in order to solve a problem. It's a fundamental concept used to solve problems that can be broken down into smaller instances of the same problem. Recursion consists of two main components: base cases and recursive cases.
-##### Base Case: 
+
+##### Base Case:
+
 Every recursive function should have one or more base cases. A base case is a condition under which the function stops calling itself and returns a result directly. Without base cases, the recursion would continue indefinitely, causing a stack overflow. Read Stack/Heap section to know more about it.
+
 ##### Recursive Case:
+
 The recursive case is where the function calls itself to solve a smaller instance of the problem. Each recursive call should bring the problem closer to a base case.
+
 #### Example
+
 ```c
 stock factorial(n) {
     // Base case: factorial of 0 is 1
@@ -1153,7 +1172,9 @@ main() {
     printf("Factorial of %d is %d", num, result); // Output: Factorial of 3 is 6
 }
 ```
+
 #### Demonstrate the Output
+
 ```
 main() \\ main function from where execution of program starts
 new num = 3; \\ creates a num variable
@@ -1169,11 +1190,15 @@ factorial(3) \\ factorial initiate
             else{ 1 * factorial(1-1) } \\ 3 * 2 * 1 and calls the factorial(0)
  	       factorial(0) \\ factorial initiate again
                if(0 == 0) return 1 \\ checks the conition which is true and return 1
-		\\ at the final call 3 * 2 * 1 * 1 
+		\\ at the final call 3 * 2 * 1 * 1
 ```
+
 ### Stack Memory
+
 The stack is a region of memory used for storing local variables, function call information, and control flow data. It operates in a Last-In-First-Out (LIFO) manner, which means that the last item pushed onto the stack is the first one to be popped off.
+
 #### Example (Stack Overflow)
+
 ```c
 #pragma dynamic 35 // (35 * 4 bytes, a cell size) #pragma dynamic [cells] helps to modify the size of stack, read docs/scripting/language/Directives to know more about #pragma
 main(){
@@ -1184,7 +1209,9 @@ grow_stacK(n){ // recursive function
 	grow_stacK(n+1);
 }
 ```
+
 #### Output
+
 ```
 N: 1
 N: 2
@@ -1192,6 +1219,7 @@ N: 3
 .. .
 Stack/heap collision (insufficient stack size)
 ```
+
 ![Stack](https://i.imgur.com/ZaIVUkJ.png)
 
 [Go Back to Contents](00-Contents)


### PR DESCRIPTION
- fix HTML minifier diagnostic error `hello world` in Greek, see pawn-lang.pdf -> page 143 or 139.
- remove pt-BR control char `DC2` and format file @itsneufox, see line 623.

```
[WARNING] Docusaurus static site generation process emitted warnings for 1 paths
This is non-critical and can be disabled with DOCUSAURUS_IGNORE_SSG_WARNINGS=true
Troubleshooting guide: https://github.com/facebook/docusaurus/discussions/10580

- "/docs/scripting/language/reference/Assorted-tips":
  - [HTML minifier diagnostic - error] Control character in input stream - {"primary_spans":[{"end":52075,"start":52073}],"span_labels":[]}
...
```