### PR TITLE
fixing a few tilde symbols that are messing up formatting

### DIFF
--- a/frontend/docs/scripting/functions/AddMenuItem.md
+++ b/frontend/docs/scripting/functions/AddMenuItem.md
@@ -41,7 +41,7 @@ public OnGameModeInit()
 - Crashes when passed an invalid menu ID.
 - You can only have 12 items per menu (13th goes to the right side of the header of column name (colored), 14th and higher not display at all).
 - You can only use 2 columns (0 and 1).
-- You can only add 8 color codes per one item (~r~, ~g~ etc.). Maximum length of menu item is 31 symbols.
+- You can only add 8 color codes per one item (`~r~`, `~g~` etc.). Maximum length of menu item is 31 symbols.
 
 :::
 

--- a/frontend/docs/scripting/functions/CreatePlayerTextDraw.md
+++ b/frontend/docs/scripting/functions/CreatePlayerTextDraw.md
@@ -49,7 +49,7 @@ Player-textdraws are automatically destroyed when a player disconnects.
 
 :::warning
 
-Keyboard key mapping codes (such as ~k~~VEHICLE_ENTER_EXIT~) Doesn't work beyond 255th character.
+Keyboard key mapping codes (such as `~k~~VEHICLE_ENTER_EXIT~`) Doesn't work beyond 255th character.
 
 :::
 

--- a/frontend/docs/scripting/functions/GameTextForAll.md
+++ b/frontend/docs/scripting/functions/GameTextForAll.md
@@ -46,7 +46,7 @@ public OnPlayerDeath(playerid, killerid, WEAPON:reason)
 
 :::warning
 
-Do note that the players may crash because of odd number of tilde (~) symbols used in the game text. Using color codes (e.g. ~r~) beyond the 255th character may crash the client.
+Do note that the players may crash because of odd number of tilde (~) symbols used in the game text. Using color codes (e.g. `~r~`) beyond the 255th character may crash the client.
 
 :::
 

--- a/frontend/docs/scripting/functions/GameTextForPlayer.md
+++ b/frontend/docs/scripting/functions/GameTextForPlayer.md
@@ -45,7 +45,7 @@ public OnPlayerDeath(playerid, killerid, WEAPON:reason)
 
 :::warning
 
-Do note that the players may crash because of odd number of tilde (~) symbols used in the game text. Using color codes (e.g. ~r~) beyond the 255th character may crash the client.
+Do note that the players may crash because of odd number of tilde (~) symbols used in the game text. Using color codes (e.g. `~r~`) beyond the 255th character may crash the client.
 
 Also, a blank space at end of the string may result in faliure. For example: `"Headshot "` results in failure. Instead it should be `"Headshot"` or `"Headshot_"`.
 

--- a/frontend/docs/scripting/functions/TextDrawCreate.md
+++ b/frontend/docs/scripting/functions/TextDrawCreate.md
@@ -58,7 +58,7 @@ public OnPlayerConnect(playerid)
 
 :::warning
 
-Keyboard key mapping codes (such as ~k~~VEHICLE_ENTER_EXIT~) don't work beyond 255th character.
+Keyboard key mapping codes (such as `~k~~VEHICLE_ENTER_EXIT~`) don't work beyond 255th character.
 
 :::
 

--- a/frontend/docs/scripting/resources/gametextstyles.md
+++ b/frontend/docs/scripting/resources/gametextstyles.md
@@ -11,7 +11,7 @@ Mainly used by [GameText](../functions/GameTextForPlayer) and [GameTextForAll](.
 
 ## Text Colors
 
-It is possible to draw certain parts of your text in different colors. To do this, you simply need to use the colour slugs listed below, and encapsulate the part of your text which you want to draw in a specific color (e.g. \~y\~I'm drawn in yellow!\~y\~).
+It is possible to draw certain parts of your text in different colors. To do this, you simply need to use the colour slugs listed below, and encapsulate the part of your text which you want to draw in a specific color (e.g. `~y~I'm drawn in yellow!~y~`).
 
 | Code                 | Colour                                                              | Description                                      |
 | -------------------- | ------------------------------------------------------------------- | ------------------------------------------------ |

--- a/frontend/docs/scripting/resources/limits.md
+++ b/frontend/docs/scripting/resources/limits.md
@@ -68,7 +68,7 @@ tags: []
 **Notes:**
 
 1. Although the vehicle model limit in 0.3 is unlimited, if you use a large amount of vehicle models then it will affect client performance.
-2. Although the textdraw string limit is 1024 characters, if colour codes (e.g. ~r~) are used beyond the 255th character it may crash the client.
+2. Although the textdraw string limit is 1024 characters, if colour codes (e.g. `~r~`) are used beyond the 255th character it may crash the client.
 3. It is possible to show all Textdraws at the same time for one player, however this is not recommended.
 4. To circumvent these limits, it is possible to use a [streamer](https://github.com/samp-incognito/samp-streamer-plugin). Streamers work by only creating the entities etc. that are close to players.
 5. Due to client limitations only up to 51 actors may actually be shown at a time.


### PR DESCRIPTION
basically a few tilde symbols were not escaped or formatted properly, giving some text unwanted ~strikethrough~ effect
i think i went through all of them, not 100% sure tho