### PR TITLE
A bit more notes to installation guide

### DIFF
--- a/frontend/docs/server/Installation.md
+++ b/frontend/docs/server/Installation.md
@@ -68,6 +68,15 @@ Put required plugins (e.g. `sscanf.dll`, `streamer.dll`) in the **plugins** fold
 
 If you use the following plugins in table, you must put a version of the plugin that is compatible with omp!
 
+:::
+
+| Plugin            | OMP                                                               |
+| ----------------- | ----------------------------------------------------------------- |
+| rustext           | https://github.com/ziggi/rustext/releases/tag/v2.0.11 (nomemhack) |
+| keylistener       | https://github.com/edgyaf/keylistener/releases/tag/1.1.2-pr       |
+
+:::warning
+
 Put the following plugins in the **../components** folder, not in the **../plugins** folder!
 
 :::
@@ -78,8 +87,7 @@ Put the following plugins in the **../components** folder, not in the **../plugi
 | Pawn.RakNet       | https://github.com/katursis/Pawn.RakNet/releases/tag/1.6.0-omp               |
 | sampvoice         | https://github.com/AmyrAhmady/sampvoice/releases/tag/v3.1.5-omp              |
 | discord-connector | https://github.com/maddinat0r/samp-discord-connector/releases/tag/v0.3.6-pre |
-| rustext           | https://github.com/ziggi/rustext/releases/tag/v2.0.11 (nomemhack)            |
-| keylistener       | https://github.com/edgyaf/keylistener/releases/tag/1.1.2-pr                  |
+| sscanf            | https://github.com/Y-Less/sscanf/releases/tag/v2.13.8                        |
 | SKY               | Use Pawn.RakNet instead                                                      |
 | YSF               | You don't need YSF because open.mp already declared most of the same natives |
 | FCNPC             | Replaced with the official open.mp NPC component                             |

--- a/frontend/i18n/fa/docusaurus-plugin-content-docs/current/server/Installation.md
+++ b/frontend/i18n/fa/docusaurus-plugin-content-docs/current/server/Installation.md
@@ -68,6 +68,15 @@ include های مورد نیاز (مثلاً `sscanf2.inc`، `streamer.inc`) ر�
 
 اگر از پلاگین‌های زیر در جدول استفاده می‌کنید، باید نسخه‌ای از پلاگین که با omp سازگار است قرار دهید!
 
+:::
+
+| پلاگین            | OMP                                                               |
+| ----------------- | ----------------------------------------------------------------- |
+| rustext           | https://github.com/ziggi/rustext/releases/tag/v2.0.11 (nomemhack) |
+| keylistener       | https://github.com/edgyaf/keylistener/releases/tag/1.1.2-pr       |
+
+:::warning
+
 پلاگین‌های زیر را در پوشه **../components** قرار دهید، نه در پوشه **../plugins**!
 
 :::
@@ -78,8 +87,7 @@ include های مورد نیاز (مثلاً `sscanf2.inc`، `streamer.inc`) ر�
 | Pawn.RakNet       | https://github.com/katursis/Pawn.RakNet/releases/tag/1.6.0-omp               |
 | sampvoice         | https://github.com/AmyrAhmady/sampvoice/releases/tag/v3.1.5-omp              |
 | discord-connector | https://github.com/maddinat0r/samp-discord-connector/releases/tag/v0.3.6-pre |
-| rustext           | https://github.com/ziggi/rustext/releases/tag/v2.0.11 (nomemhack)            |
-| keylistener       | https://github.com/edgyaf/keylistener/releases/tag/1.1.2-pr                  |
+| sscanf            | https://github.com/Y-Less/sscanf/releases/tag/v2.13.8                        |
 | SKY               | به جای آن از Pawn.RakNet استفاده کنید                                      |
 | YSF               | شما نیازی به YSF ندارید زیرا open.mp قبلاً بیشتر همان native ها را اعلان کرده |
 | FCNPC             | در حال حاضر پشتیبانی نمی‌شود                                                      |

--- a/frontend/i18n/nl/docusaurus-plugin-content-docs/current/server/Installation.md
+++ b/frontend/i18n/nl/docusaurus-plugin-content-docs/current/server/Installation.md
@@ -62,6 +62,15 @@ Plaats vereiste plugins (bijv. `sscanf.dll`, `streamer.dll`) in de map **plugins
 
 Als je de onderstaande plugins gebruikt, moet je een versie gebruiken die compatibel is met omp!
 
+:::
+
+| Plugin            | OMP                                                               |
+| ----------------- | ----------------------------------------------------------------- |
+| rustext           | https://github.com/ziggi/rustext/releases/tag/v2.0.11 (nomemhack) |
+| keylistener       | https://github.com/edgyaf/keylistener/releases/tag/1.1.2-pr       |
+
+:::warning
+
 Plaats de volgende plugins in de map **../components**, niet in **../plugins**!
 
 :::
@@ -72,8 +81,7 @@ Plaats de volgende plugins in de map **../components**, niet in **../plugins**!
 | Pawn.RakNet       | https://github.com/katursis/Pawn.RakNet/releases/tag/1.6.0-omp               |
 | sampvoice         | https://github.com/AmyrAhmady/sampvoice/releases/tag/v3.1.5-omp              |
 | discord-connector | https://github.com/maddinat0r/samp-discord-connector/releases/tag/v0.3.6-pre |
-| rustext           | https://github.com/ziggi/rustext/releases/tag/v2.0.11 (nomemhack)            |
-| keylistener       | https://github.com/edgyaf/keylistener/releases/tag/1.1.2-pr                  |
+| sscanf            | https://github.com/Y-Less/sscanf/releases/tag/v2.13.8                        |
 | SKY               | Gebruik Pawn.RakNet in plaats daarvan                                        |
 | YSF               | Niet nodig: open.mp heeft de meeste gelijkwaardige natives al                |
 | FCNPC             | Momenteel niet ondersteund                                                   |

--- a/frontend/i18n/pt-BR/docusaurus-plugin-content-docs/current/server/Installation.md
+++ b/frontend/i18n/pt-BR/docusaurus-plugin-content-docs/current/server/Installation.md
@@ -62,6 +62,15 @@ Coloque os plugins necessários (por exemplo, `sscanf.dll`, `streamer.dll`) na p
 
 Se você usa os seguintes plugins da tabela, você deve colocar uma versão do plugin que seja compatível com omp!
 
+:::
+
+| Plugin            | OMP                                                               |
+| ----------------- | ----------------------------------------------------------------- |
+| rustext           | https://github.com/ziggi/rustext/releases/tag/v2.0.11 (nomemhack) |
+| keylistener       | https://github.com/edgyaf/keylistener/releases/tag/1.1.2-pr       |
+
+:::warning
+
 Coloque os seguintes plugins na pasta **../components**, não na pasta **../plugins**!
 
 :::
@@ -72,8 +81,7 @@ Coloque os seguintes plugins na pasta **../components**, não na pasta **../plug
 | Pawn.RakNet       | https://github.com/katursis/Pawn.RakNet/releases/tag/1.6.0-omp                    |
 | sampvoice         | https://github.com/AmyrAhmady/sampvoice/releases/tag/v3.1.5-omp                   |
 | discord-connector | https://github.com/maddinat0r/samp-discord-connector/releases/tag/v0.3.6-pre      |
-| rustext           | https://github.com/ziggi/rustext/releases/tag/v2.0.11 (nomemhack)                 |
-| keylistener       | https://github.com/edgyaf/keylistener/releases/tag/1.1.2-pr                       |
+| sscanf            | https://github.com/Y-Less/sscanf/releases/tag/v2.13.8                             |
 | SKY               | Use Pawn.RakNet em vez disso                                                      |
 | YSF               | Você não precisa do YSF porque o open.mp já declarou a maioria das mesmas natives |
 | FCNPC             | Substituído pelo componente oficial de NPC do open.mp                             |

--- a/frontend/i18n/zh-CN/docusaurus-plugin-content-docs/current/server/Installation.md
+++ b/frontend/i18n/zh-CN/docusaurus-plugin-content-docs/current/server/Installation.md
@@ -68,6 +68,15 @@ description: 将游戏模式从 SA:MP 服务器迁移至 open.mp 服务器的指
 
 下表所列插件必须使用兼容 omp 的版本！
 
+:::
+
+| 插件              | OMP 兼容版本                                                      |
+| ----------------- | ----------------------------------------------------------------- |
+| rustext           | https://github.com/ziggi/rustext/releases/tag/v2.0.11 (nomemhack) |
+| keylistener       | https://github.com/edgyaf/keylistener/releases/tag/1.1.2-pr       |
+
+:::warning
+
 请将以下插件放入 **../components** 目录而非 **../plugins**！
 
 :::
@@ -78,8 +87,7 @@ description: 将游戏模式从 SA:MP 服务器迁移至 open.mp 服务器的指
 | Pawn.RakNet       | https://github.com/katursis/Pawn.RakNet/releases/tag/1.6.0-omp               |
 | sampvoice         | https://github.com/AmyrAhmady/sampvoice/releases/tag/v3.1.5-omp              |
 | discord-connector | https://github.com/maddinat0r/samp-discord-connector/releases/tag/v0.3.6-pre |
-| rustext           | https://github.com/ziggi/rustext/releases/tag/v2.0.11 (nomemhack)            |
-| keylistener       | https://github.com/edgyaf/keylistener/releases/tag/1.1.2-pr                  |
+| sscanf            | https://github.com/Y-Less/sscanf/releases/tag/v2.13.8                        |
 | SKY               | 改用 Pawn.RakNet                                                             |
 | YSF               | 无需使用，open.mp 已原生支持大部分功能                                       |
 | FCNPC             | 传统的 FCNPC 插件已被官方的 open.mp NPC 组件 取代                              |


### PR DESCRIPTION
Reading this article more deeply I noticed that listed plugins have pretty much different purposes to be in this unified list of "plugins to be updated": some of them have to be replaced with adapted components (or they won't work at all), some has component version with just better omp support (comparing to its plugin version), and some like recently added, was adapted but without a need to be components. So I decided to split up this one single list into two, thus it will be clear what must be moved exactly to components folder and what should be stay exactly in plugins folder, even considering it was also tweaked for omp.

Btw also added sscanf component to the second list as we already have similarly updated discord-connector with a bit better omp support being in component.