### PR TITLE
Fix misleading info in porting post

### DIFF
--- a/frontend/blog/2024-03-06-porting.md
+++ b/frontend/blog/2024-03-06-porting.md
@@ -97,14 +97,6 @@ public OnPlayerConnect(playerid)
 }
 ```
 
-## `ClearAnimations`
-
-`ClearAnimations` is the dual of `ApplyAnimation` to stop a player performing the action previously requested. However, when used on a player in a vehicle this would also cause the player to be removed from the vehicle. This is a useful function, as it happens instantly, but is not within the purview of the `ClearAnimations` function. To force remove a player from a vehicle instantly use:
-
-```c
-RemovePlayerFromVehicle(playerid, true);
-```
-
 ## Death money
 
 When a player dies in San Andreas they get $100 deducted from them to cover hospital bills automatically. This feature remains in SA:MP, but is removed from open.mp to allow scripts to manage all their own money. Several scripts attempt to fix this already by adding $100 to a player after death, or on spawn. If this is your script simply delete the additional fix, although the code in open.mp does attempt to account for scripts that do this. If your script relied on this feature, simply add the following code to `OnPlayerDeath`:
@@ -112,67 +104,6 @@ When a player dies in San Andreas they get $100 deducted from them to cover hosp
 ```c
 GivePlayerMoney(playerid, -100);
 ```
-
-## `OnPlayerConnect`
-
-When a gamemode starts or restarts in SA:MP `OnPlayerConnect` is immediately called for all players already connected to the server, but it isn't when a filterscript starts or restarts. While the latter behaviour more closely matches the name, the former behaviour is extremely widely exploited in scripts, and so was extended to all script types in open.mp to maintain consistency.
-
-Scripts which initialise data for a player no longer need to perform this code in two different locations:
-
-```c
-public OnFilterScriptInit()
-{
-    for (new playerid = 0; playerid != MAX_PLAYERS; ++playerid)
-    {
-        if (IsPlayerConnected(playerid))
-        {
-            InitialisePlayer(playerid);
-        }
-    }
-}
-
-public OnPlayerConnect(playerid)
-{
-    InitialisePlayer(playerid);
-}
-```
-
-The loop in OnFilterScriptInit can now be removed:
-
-```c
-public OnPlayerConnect(playerid)
-{
-    InitialisePlayer(playerid);
-}
-```
-
-If a script exploited this fact to only run code for new players joining the server after the scripts starts, and not for those who were on before, this will no longer work, but is again easilly fixed:
-
-```c
-static bool:gAlreadyHere[MAX_PLAYERS];
-
-public OnFilterScriptInit()
-{
-    for (new playerid = 0; playerid != MAX_PLAYERS; ++playerid)
-    {
-        gAlreadyHere[playerid] = IsPlayerConnected(playerid);
-    }
-}
-
-public OnPlayerConnect(playerid)
-{
-    if (gAlreadyHere[playerid])
-    {
-        gAlreadyHere[playerid] = false;
-    }
-    else
-    {
-        SendClientMessage(playerid, COLOUR_WARN, "You're late!");
-    }
-}
-```
-
-This may look to simply trade one loop in `OnFilterScriptInit` off for another one, but wanting to exclude current players from some code is a less common use-case than wanting to do something for everyone, so this is overall a net improvement; and as stated before vastly less invasive than not calling `OnPlayerConnect` in gamemodes.
 
 ## Game texts
 
@@ -217,14 +148,14 @@ Though since the highest value is a real player when there are people online thi
 
 ## Spellings
 
-SA:MP is very inconsistent in its code spellings - some things use English, some things use American:
+SA:MP is very inconsistent in its code spellings - some things use British English, some things use American:
 
-- `Bumper` - English
+- `Bumper` - British
 - `Hood` - American
-- `Armour` - English
+- `Armour` - British
 - `Stereo` - American
 
-We have unified these, and settled on English spellings. So for example:
+We have unified these, and settled on British spellings. So for example:
 
 ```c
 TextDrawBoxColor(Text:textid, boxColor);


### PR DESCRIPTION
Firstly I'd like to say I'm not keen on rewriting anything in blog post section since it has historical purposes to be there as it was written initially, but [this article](https://open.mp/blog/porting) quite easily searchable by anything like "port to open.mp" and may look like the actual relevant information, which people may wrongfully refer to, even remembering it's not docs article.

And since it has some confusing things which literally give misleading stuff for people who don't expect it from an official source, I've changed some of the things there to be more or less relevant for the current open.mp server.