### PR TITLE
chore: updated outdated links, added ompgo and pawn playground

### DIFF
--- a/frontend/docs/awesome.md
+++ b/frontend/docs/awesome.md
@@ -8,10 +8,10 @@ description: A curated list of useful tools, libraries, gamemodes, filterscripts
 
 - **[Community Compiler](https://github.com/pawn-lang/compiler)** - A vastly updated version of the compiler, with many fixes and enhancements.
 - **[sampctl](https://github.com/Southclaws/sampctl)** - Package manager for installing libraries and running your server.
-- **[Plugin Runner](https://github.com/Zeex/samp-plugin-runner)** - Tool to run a lightweight version of the server directly from command-line (no server.cfg required) for testing plugins.
+- **[Plugin Runner](https://github.com/Y-Less/samp-plugin-runner)** - Tool to run a lightweight version of the server directly from command-line (no server.cfg required) for testing plugins.
 - **[Plugin Boilerplate](https://github.com/Southclaws/samp-plugin-boilerplate)** - Making a plugin easier with boilerplate.
 - **[SA:MP Plugin Template Library](https://github.com/katursis/samp-ptl)** - Making your own plugins very easy and fast with this template library.
-- **[SA-MP Fiddle](https://fiddle.sa-mp.dev)** - A place to test your scripts (snippets, PoC, debugging, etc) and share it to others.
+- **[Pawn Playground](https://pg.open.mp)** - An official online pawn code playground provided by open.mp.
 - **[Pawn Syntax - Sublime](https://packagecontrol.io/packages/Pawn%20syntax)** - Pawn autocompletes for Sublime Text.
 - **[Pawn Syntax - Visual Marketplace](https://marketplace.visualstudio.com/items?itemName=southclaws.vscode-pawn)** - Pawn autocompletes for Visual Studio Code.
 - **[SA-MP Zone Editor](https://bitbucket.org/Grimrandomer/samp-zone-editor/downloads)** - Zone Editor for making Area and stuff.
@@ -134,6 +134,7 @@ Now you can make your scripts in languages other than pawn without any plugin us
 - **[SampSharp](https://github.com/ikkentim/SampSharp)** - C# Language Support for writing a gamemode for SA:MP
 - **[.NET Plugin](https://github.com/Seregamil/.NET-plugin)** - C# Language Support for writing a plugin for SA:MP
 - **[sampgo](https://github.com/sampgo/sampgo)** - Go Language Support for writing a gamemode/plugins for SA:MP
+- **[ompgo](https://github.com/ompgo-dev/ompgo)** - Go Language Support for writing a gamemode/components for open.mp
 - **[samp-node](https://github.com/AmyrAhmady/samp-node)** - Javascript/Typescript Language Support for writing a gamemode for SA:MP
 - **[Shoebill Project](https://github.com/Shoebill/ShoebillPlugin)** - Java Language Support for writing a gamemode for SA:MP
 - **[pySAMP](https://github.com/habecker/PySAMP)** - Python Language Support for writing a gamemode for SA:MP


### PR DESCRIPTION
This pull request updates the curated list of tools and language support libraries in `frontend/docs/awesome.md` to reflect more accurate and up-to-date resources for SA:MP and open.mp development.

**Tool and library updates:**

* Updated the link for **Plugin Runner** to the new repository at `Y-Less/samp-plugin-runner`, the Zeex one is not available anymore.
* Replaced **SA-MP Fiddle** with **Pawn Playground**, the official online Pawn code playground provided by open.mp. SA-MP Fiddle is offline and no longer accessible.

**Language support additions:**

* Added **ompgo** as a new entry for Go language support for writing gamemodes/components for open.mp.