### PR TITLE
i18n improvements: dynamic footer year + Ukrainian ownership updates

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,3 +10,4 @@
 /frontend/i18n/ar/                                                          @midosvt @ImOver00
 /frontend/i18n/sv/                                                          @fusez
 /frontend/i18n/vi/                                                          @PHATBENTRE
+/frontend/i18n/uk/                                                          @justdawy

--- a/frontend/docusaurus.config.ts
+++ b/frontend/docusaurus.config.ts
@@ -5,6 +5,18 @@ import { themes as prismThemes } from "prism-react-renderer";
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
+const currentYear = new Date().getFullYear();
+
+const copyrightByLocale: Record<string, string> = {
+  en: `Copyright © ${currentYear} open.mp. Built with Docusaurus.`,
+  uk: `Copyright © ${currentYear} open.mp. Створено на Docusaurus.`,
+  "pt-BR": `Copyright © ${currentYear} open.mp. Feito com Docusaurus.`,
+  "zh-CN": `版权所有 © ${currentYear} open.mp。基于Docusaurus构建"`,
+  tr: `Telif Hakkı © ${currentYear} open.mp. Docusaurus ile yapıldı.`,
+  fa: `حق نشر © ${currentYear} open.mp. ساخته شده با Docusaurus.`,
+
+};
+
 const config: Config = {
   title: "open.mp",
   tagline: "Open Multiplayer",
@@ -330,7 +342,10 @@ const config: Config = {
           ],
         },
       ],
-      copyright: `Copyright © ${new Date().getFullYear()} open.mp. Built with Docusaurus.`,
+      copyright:
+        copyrightByLocale[
+        process.env.DOCUSAURUS_CURRENT_LOCALE || "en"
+        ] || copyrightByLocale.en,
     },
     prism: {
       theme: prismThemes.github,

--- a/frontend/i18n/fa/docusaurus-theme-classic/footer.json
+++ b/frontend/i18n/fa/docusaurus-theme-classic/footer.json
@@ -62,9 +62,5 @@
   "link.item.label.SA-MP": {
     "message": "SA-MP",
     "description": "The label of footer link with label=SA-MP linking to https://sa-mp.mp/"
-  },
-  "copyright": {
-    "message": "حق نشر © 2025 open.mp. ساخته شده با Docusaurus.",
-    "description": "The footer copyright"
   }
 }

--- a/frontend/i18n/pt-BR/docusaurus-theme-classic/footer.json
+++ b/frontend/i18n/pt-BR/docusaurus-theme-classic/footer.json
@@ -62,9 +62,5 @@
   "link.item.label.SA-MP": {
     "message": "SA-MP",
     "description": "The label of footer link with label=SA-MP linking to https://sa-mp.mp/"
-  },
-  "copyright": {
-    "message": "Copyright © 2025 open.mp. Feito com Docusaurus.",
-    "description": "The footer copyright"
   }
 }

--- a/frontend/i18n/tr/docusaurus-theme-classic/footer.json
+++ b/frontend/i18n/tr/docusaurus-theme-classic/footer.json
@@ -62,9 +62,5 @@
   "link.item.label.SA-MP": {
     "message": "SA-MP",
     "description": "The label of footer link with label=SA-MP linking to https://sa-mp.mp/"
-  },
-  "copyright": {
-    "message": "Telif Hakkı © {year} open.mp. Docusaurus ile yapıldı.",
-    "description": "The footer copyright"
   }
 }

--- a/frontend/i18n/uk/docusaurus-theme-classic/footer.json
+++ b/frontend/i18n/uk/docusaurus-theme-classic/footer.json
@@ -62,9 +62,5 @@
   "link.item.label.SA-MP": {
     "message": "SA-MP",
     "description": "The label of footer link with label=SA-MP linking to https://sa-mp.mp/"
-  },
-  "copyright": {
-    "message": "Copyright © {year} open.mp. Створено на Docusaurus.",
-    "description": "The footer copyright"
   }
 }

--- a/frontend/i18n/zh-CN/docusaurus-theme-classic/footer.json
+++ b/frontend/i18n/zh-CN/docusaurus-theme-classic/footer.json
@@ -62,9 +62,5 @@
   "link.item.label.SA-MP": {
     "message": "SA-MP",
     "description": "标签为SA-MP的页脚链接，指向https://sa-mp.mp/"
-  },
-  "copyright": {
-    "message": "版权所有 © 2025 open.mp。基于Docusaurus构建",
-    "description": "页脚版权信息"
   }
 }


### PR DESCRIPTION
This PR improves internationalization handling and repository ownership configuration.

✨ Changes
- Implement dynamic footer year across all locales
- Improve i18n footer handling consistency
- Add CODEOWNERS entry for /frontend/i18n/uk/

🌍 i18n notes
 - Docusaurus i18n JSON files do not support runtime variable interpolation (e.g. {year}), so the footer year is now handled dynamically in the React/theme layer instead of translation files.

🧪 Testing
- Tested locally with multiple locales enabled (en, uk, pt-BR, tr, etc.)
- Verified footer renders correct year across all languages
