### PR TITLE
fix: redsands west incorrect coordinates

### DIFF
--- a/frontend/docs/scripting/resources/interiorids.md
+++ b/frontend/docs/scripting/resources/interiorids.md
@@ -42,7 +42,7 @@ and you'll see the ID of the interior universe. Now you can safely use [SetPlaye
 | Interior               | Interior ID | X         | Y         | Z         | Picture                                                             |
 | ---------------------- | ----------- | --------- | --------- | --------- | ------------------------------------------------------------------- |
 | Four Dragons           | 10          | 2016.1156 | 1017.1541 | 996.875   | ![](https://assets.open.mp/assets/images/interiors/interior41.png)  |
-| Casino (Redsands West) | 12          | 1000.6797 | 1133.35   | -7.8462   | ![](https://assets.open.mp/assets/images/interiors/interior62.png)  |
+| Casino (Redsands West) | 12          | 1133.2007 | -15.7586  | 1000.3251   | ![](https://assets.open.mp/assets/images/interiors/interior62.png)  |
 | Caligula's Casino      | 1           | 2233.9363 | 1711.8038 | 1011.6312 | ![](https://assets.open.mp/assets/images/interiors/interior48.png)  |
 | Caligula's Roof        | 1           | 2268.5156 | 1647.7682 | 1084.2344 | ![](https://assets.open.mp/assets/images/interiors/interior131.png) |
 


### PR DESCRIPTION
The Redsands West position was incorrect. This patch places them at the door (entrance) of the casino.