### PR TITLE
refactor: expand and tidy the glossary

### DIFF
--- a/frontend/docs/scripting/resources/glossary.md
+++ b/frontend/docs/scripting/resources/glossary.md
@@ -5,17 +5,55 @@ description: Glossary of terms
 tags: []
 ---
 
-| Word                                              | Meaning                                                                                                 |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| PAWN                                              | The scripting language used to make SA:MP scripts                                                       |
-| Gamemodes                                         | The main script that runs on a server                                                                   |
-| Filterscripts                                     | Scripts that run alongside gamemodes                                                                    |
-| Plugins                                           | Extra functions/capabilites added through a .dll (Windows) or .so (Linux) file                          |
-| Include                                           | Pieces of script placed in .inc files to be included in Filterscripts/Gamemodes using `#include <name>` |
-| Pawno                                             | The script editor most people use for PAWN                                                              |
-| [Qawno](https://github.com/openmultiplayer/qawno) | The script editor most people use for PAWN                                                              |
-| Pawncc                                            | The compiler that compiles .pwn to .amx                                                                 |
-| Masterlist                                        | The server SA:MP stores its data on such as the Internet list                                           |
-| Deathmatch                                        | A contest where players try to kill each other to win                                                   |
-| Roleplay                                          | A gamemode type where players acting like in real life                                                  |
-| Reallife                                          | A gamemode type which is based on real life but players do not need to act like in real life            |
+## Scripting
+
+| Word         | Meaning                                                                                                 |
+| ------------ | ------------------------------------------------------------------------------------------------------- |
+| PAWN         | The scripting language used to make SA:MP and open.mp scripts                                           |
+| Gamemode     | The main script that runs on a server                                                                   |
+| Filterscript | Scripts that run alongside gamemodes                                                                    |
+| Plugin       | Extra functions/capabilities added through a .dll (Windows) or .so (Linux) file                         |
+| Component    | The open.mp equivalent of a plugin, loaded from the `components` folder                                 |
+| Include      | Pieces of script placed in .inc files to be included in Filterscripts/Gamemodes using `#include <name>` |
+| Native       | A function provided by the server or a plugin that can be called from PAWN                              |
+| Callback     | A function automatically called by the server when a specific event occurs (e.g. OnPlayerConnect)       |
+| AMX          | The compiled file (.amx) produced from a .pwn source file, which the server actually runs               |
+| Tick         | One millisecond of server time, as counted by [GetTickCount](../functions/GetTickCount)                 |
+
+## Tools
+
+| Word                                              | Meaning                                                                  |
+| ------------------------------------------------- | ------------------------------------------------------------------------ |
+| Pawno                                             | The original SA:MP script editor for PAWN, Windows only and unmaintained |
+| [Qawno](https://github.com/openmultiplayer/qawno) | The script editor that ships with open.mp, and the replacement for Pawno |
+| Pawncc                                            | The compiler that compiles .pwn to .amx                                  |
+
+## Networking
+
+| Word       | Meaning                                                                                                              |
+| ---------- | -------------------------------------------------------------------------------------------------------------------- |
+| Client     | The game application used by players to connect to a multiplayer server                                              |
+| Server     | The application that hosts a multiplayer game and manages connected clients                                          |
+| Masterlist | The public list of running servers, which servers announce themselves to and clients read to fill the server browser |
+| Sync       | The process of keeping the game state consistent between the server and connected clients                            |
+| Desync     | A situation where the game state differs between the server and one or more clients                                  |
+| Ping       | The round-trip time for data to travel between a client and the server, measured in milliseconds                     |
+
+## Entities
+
+| Word  | Meaning                                                                                                            |
+| ----- | ------------------------------------------------------------------------------------------------------------------ |
+| NPC   | A non-player character that connects to the server like a player and is driven by a script, and uses a player slot |
+| Actor | A static non-player character used for decoration or interaction, such as a cashier, that uses no player slot      |
+
+## Common gamemode types
+
+| Word             | Meaning                                                                                                    |
+| ---------------- | ---------------------------------------------------------------------------------------------------------- |
+| Deathmatch       | A gamemode type where players try to kill each other to win                                                |
+| Roleplay         | A gamemode type where players act like in real life and are expected to stay in character                  |
+| Reallife         | A gamemode type which is based on real life but players do not need to act like in real life               |
+| Cops and Robbers | A gamemode type where criminals commit crimes while police attempt to stop and arrest them                 |
+| Derby / Sumo     | A gamemode type where players try to knock opponents out of an arena with vehicles                         |
+| Survival         | A gamemode type where players must survive against environmental hazards, such as zombies or other players |
+| Freeroam         | A gamemode type with no set objective, where players are free to explore, stunt and fight as they please   |


### PR DESCRIPTION
The glossary has been the same for a while and it's missing most of the words people actually run into when they start scripting. Nothing in it explains what a callback or native is, or i.e. what sync means.

So this PR aims to add the missing terms and tries to group things by topic: Scripting, Tools, Networking, Entities, Gamemode types. The reason for the headers is because the additions I made turned it into one long alphabet-soup table, which was a bit hard to read.

__**New additions**__: Native, Callback, Component, AMX, Tick, Client, Server, Sync, Desync, Ping, NPC, Actor, Cops and Robbers, Derby / Sumo, Survival, Freeroam.

I primarily looked in #pawn-help on Discord and added questions that often appear, i.e. actors vs npcs, what are components, etc. The rest I've filled in to the best of my knowledge, but would love if somebody else can cross check to make sure it's properly explained, especially the networking area. 

__**I also rewrote a few things in the existing rows**:__

- Pawno and Qawno had the same description ("the script editor most people use for PAWN"), which doesn't tell anyone which one to open. Pawno is the old SA:MP editor, Windows only. Qawno ships with open.mp and is also cross-platform(?).
- The Masterlist row previously stated "The server SA:MP stores its data on such as the Internet list", which doesn't really describe what the masterlist is or does. Rewritten to be a bit more obvious.
- PAWN was described as the language for SA:MP scripts. These are the open.mp docs, so open.mp is now named too.
- Roleplay: "where players acting like in real life" -> fixed grammar, and it now says players are expected to stay in character, which is the actual difference from Reallife.
- Some typos fixed, for example in Plugins ("capabilites"), and the Word column is singular now (Gamemode instead of Gamemodes) since each row describes it's own thing.

Let me know what you guys think or if you guys have any suggestions/feedback.
