### PR TITLE
feat: add prineside's object browser, weather gallery and gangzone editor

### DIFF
--- a/frontend/docs/awesome.md
+++ b/frontend/docs/awesome.md
@@ -16,6 +16,10 @@ description: A curated list of useful tools, libraries, gamemodes, filterscripts
 - **[Pawn Syntax - Visual Marketplace](https://marketplace.visualstudio.com/items?itemName=southclaws.vscode-pawn)** - Pawn autocompletes for Visual Studio Code.
 - **[SA-MP Zone Editor](https://bitbucket.org/Grimrandomer/samp-zone-editor/downloads)** - Zone Editor for making Area and stuff.
 - **[SA-MP Map Editor](https://github.com/openmultiplayer/archive/raw/master/tools/Map%20Editor.zip)** - Popular Map Editor for SA:MP.
+- **[Prineside's Object Model Browser](https://dev.prineside.com/en/gtasa_samp_model_id/)** - Extensive website that makes it easy to browse object model IDs, get object lod data, browse all textures and pinpoint where the objects are used in GTA San Andreas on an interactive map.
+- **[Prineside's Weather Gallery](https://dev.prineside.com/en/gtasa_samp_model_id/)** - Interactive online gallery for every available weather in the game for every ingame hour.
+- **[Prineside's Gangzone Editor](https://dev.prineside.com/en/gtasa_gangzone_editor/)** - Interactive online gangzone creator
+
 
 ## Libraries
 


### PR DESCRIPTION
Since a lot of the map editors and gangzone editors are download only, I thought it could be nice to have online variants. All of the tools are online and are very feature rich. 

The object browser has everything you would expect, from searching by name or model id, to showing the sizes of the object, the used textdraws (with a link of the txd library and a rendered sprite of all textures), showing whether the model has collision, particles, is breakable, and more.

The weather gallery allows you to preview weathers online for any kind of ingame time, with the ability to filter the broken weather IDs. Clicking on a weather plays a little preview video where you can easily scroll between the available times.

The gangzone editor is pretty self explanatory. The export returns raw data, so you can use it for Streamer areas as well.

I understand it's a third party website which may be frowned upon but it's been online for at least 10 years. I recall using it during WW-RP's development and that was in 2016, so I don't think it's going down any time soon.

Hopefully this can be added so that other scripters can also benefit from these tools.