### PR TITLE
Add docs android widgets page

### DIFF
--- a/frontend/docs/scripting/functions/GameTextForAll.md
+++ b/frontend/docs/scripting/functions/GameTextForAll.md
@@ -50,6 +50,12 @@ Do note that the players may crash because of odd number of tilde (~) symbols us
 
 :::
 
+:::tip
+
+Android Clients can render some UI elements (called internally as widgets) directly in text, see [this page for more information](../resources/android-widgets.md).
+
+:::
+
 ## Related Functions
 
 - [HideGameTextForAll](HideGameTextForAll): Stop showing a gametext style for all players.

--- a/frontend/docs/scripting/functions/GameTextForPlayer.md
+++ b/frontend/docs/scripting/functions/GameTextForPlayer.md
@@ -51,6 +51,12 @@ Also, a blank space at end of the string may result in faliure. For example: `"H
 
 :::
 
+:::tip
+
+Android Clients can render some UI elements (called internally as widgets) directly in text, see [this page for more information](../resources/android-widgets.md).
+
+:::
+
 ## Related Functions
 
 - [HideGameTextForPlayer](HideGameTextForPlayer): Stop showing a gametext style to a player.

--- a/frontend/docs/scripting/functions/TextDrawCreate.md
+++ b/frontend/docs/scripting/functions/TextDrawCreate.md
@@ -62,6 +62,12 @@ Keyboard key mapping codes (such as `~k~~VEHICLE_ENTER_EXIT~`) don't work beyond
 
 :::
 
+:::tip
+
+Android Clients can render some UI elements (called internally as widgets) directly in text, see [this page for more information](../resources/android-widgets.md).
+
+:::
+
 ## Related Functions
 
 - [TextDrawDestroy](TextDrawDestroy): Destroy a textdraw.

--- a/frontend/docs/scripting/resources/android-widgets.md
+++ b/frontend/docs/scripting/resources/android-widgets.md
@@ -9,19 +9,17 @@ Mainly used by [GameText](../functions/GameTextForPlayer), [GameTextForAll](../f
 
 ---
 
-:::caution
+Widgets can be used mid-text in a GameText or TextDraw.
 
-Attempting to show one of this widgets to a PC player will show either some corrupted text or a error saying there's a mismatch in the tildes in the text.
-When it shows the corrupted text, the PC client appears to try to find the resource for the widget, but fails since it doesn't exists.
-
-:::
+To use, simply place `~m~~code~` in the middle of the text, replacing `code` with one of the codes listed below.
 
 :::caution
 
-Due do inconsistencies in how Android Clients are implemented, it's possible not all widgets will be available for all clients, or even show for some clients, but not for others.
+The codes only render correctly on android clients.
 
 :::
 
+## Code list
 
 | Code | Image | Notes |
 | --- | --- | --- |
@@ -149,3 +147,19 @@ Due do inconsistencies in how Android Clients are implemented, it's possible not
 | widget_video_poker_exit |![](https://assets.open.mp/widgets/widget_video_poker_exit.png) | |
 | widget_zoom_in |![](https://assets.open.mp/widgets/widget_zoom_in.png) | |
 | widget_zoom_out |![](https://assets.open.mp/widgets/widget_zoom_out.png) | Did not load on Thunder Client |
+
+
+## Notes
+
+:::caution
+
+Attempting to show one of this widgets to a PC player will show either some corrupted text or a error saying there's a mismatch in the tildes in the text.
+When it shows the corrupted text, the PC client appears to try to find the resource for the widget, but fails since it doesn't exists.
+
+:::
+
+:::caution
+
+Due do inconsistencies in how Android Clients are implemented, it's possible not all widgets will be available for all clients, or even show for some clients, but not for others.
+
+:::

--- a/frontend/docs/scripting/resources/android-widgets.md
+++ b/frontend/docs/scripting/resources/android-widgets.md
@@ -1,0 +1,151 @@
+---
+title: Android Widgets
+sidebar_label: Android Widgets
+description: Android button widegets used in textdraws and gametext.
+---
+
+This page covers everything you need to know about android widgets, and how they can be used in textdraws and in text rendered for a (single) player.
+Mainly used by [GameText](../functions/GameTextForPlayer), [GameTextForAll](../functions/GameTextForAll), [TextDrawCreate](../functions/TextDrawCreate) and [PlayerTextDrawCreate](../functions/PlayerTextDrawCreate).
+
+---
+
+:::caution
+
+Attempting to show one of this widgets to a PC player will show either some corrupted text or a error saying there's a mismatch in the tildes in the text.
+When it shows the corrupted text, the PC client appears to try to find the resource for the widget, but fails since it doesn't exits.
+
+:::
+
+:::caution
+
+Due do inconsistencies in how Android Clients are implemented, it's possible not all widgets will be available for all clients, or even show for some clients, but not for others.
+
+:::
+
+
+| Code | Image | Notes |
+| --- | --- | --- |
+| widget_accelerate |![](https://assets.open.mp/widgets/widget_accelerate.png) | |
+| widget_air_gun |![](https://assets.open.mp/widgets/widget_air_gun.png) | |
+| widget_arcade_button |![](https://assets.open.mp/widgets/widget_arcade_button.png) | |
+| widget_arcade_joystick |![](https://assets.open.mp/widgets/widget_arcade_joystick.png) | Did not load on Thunder Client |
+| widget_arcade_power_off |![](https://assets.open.mp/widgets/widget_arcade_power_off.png) | |
+| widget_arcade_reset |![](https://assets.open.mp/widgets/widget_arcade_reset.png) | |
+| widget_attack |![](https://assets.open.mp/widgets/widget_attack.png) | |
+| widget_auto_hydraulics |![](https://assets.open.mp/widgets/widget_auto_hydraulics.png) | |
+| widget_basketball_shoot |![](https://assets.open.mp/widgets/widget_basketball_shoot.png) | |
+| widget_black_jack_double |![](https://assets.open.mp/widgets/widget_black_jack_double.png) | |
+| widget_black_jack_hit |![](https://assets.open.mp/widgets/widget_black_jack_hit.png) | |
+| widget_black_jack_split |![](https://assets.open.mp/widgets/widget_black_jack_split.png) | |
+| widget_black_jack_stand |![](https://assets.open.mp/widgets/widget_black_jack_stand.png) | |
+| widget_brake |![](https://assets.open.mp/widgets/widget_brake.png) | |
+| widget_button_dive |![](https://assets.open.mp/widgets/widget_button_dive.png) | |
+| widget_button_swim |![](https://assets.open.mp/widgets/widget_button_swim.png) | |
+| widget_camera |![](https://assets.open.mp/widgets/widget_camera.png) | |
+| widget_crane_down |![](https://assets.open.mp/widgets/widget_crane_down.png) | |
+| widget_crane_up |![](https://assets.open.mp/widgets/widget_crane_up.png) | |
+| widget_drop_crane |![](https://assets.open.mp/widgets/widget_drop_crane.png) | |
+| widget_drop_item |![](https://assets.open.mp/widgets/widget_drop_item.png) | |
+| widget_enter_car |![](https://assets.open.mp/widgets/widget_enter_car.png) | |
+| widget_enter_targeting |![](https://assets.open.mp/widgets/widget_enter_targeting.png) | |
+| widget_explicit_NVG |![](https://assets.open.mp/widgets/widget_explicit_NVG.png) | |
+| widget_explicit_accept |![](https://assets.open.mp/widgets/widget_explicit_accept.png) | Did not load on Thunder Client |
+| widget_explicit_alt_attack |![](https://assets.open.mp/widgets/widget_explicit_alt_attack.png) | Did not load on Thunder Client |
+| widget_explicit_bicycle |![](https://assets.open.mp/widgets/widget_explicit_bicycle.png) | Did not load on Thunder Client |
+| widget_explicit_bunny_hop |![](https://assets.open.mp/widgets/widget_explicit_bunny_hop.png) | Did not load on Thunder Client |
+| widget_explicit_camera_zoom_in |![](https://assets.open.mp/widgets/widget_explicit_camera_zoom_in.png) | Did not load on Thunder Client |
+| widget_explicit_camera_zoom_out |![](https://assets.open.mp/widgets/widget_explicit_camera_zoom_out.png) | Did not load on Thunder Client |
+| widget_explicit_crouch |![](https://assets.open.mp/widgets/widget_explicit_crouch.png) | Did not load on Thunder Client |
+| widget_explicit_detonator |![](https://assets.open.mp/widgets/widget_explicit_detonator.png) | |
+| widget_explicit_extinguisher |![](https://assets.open.mp/widgets/widget_explicit_extinguisher.png) | |
+| widget_explicit_flight_ascend |![](https://assets.open.mp/widgets/widget_explicit_flight_ascend.png) | Did not load on Thunder Client |
+| widget_explicit_flight_descend |![](https://assets.open.mp/widgets/widget_explicit_flight_descend.png) | Did not load on Thunder Client |
+| widget_explicit_flight_primary_attack |![](https://assets.open.mp/widgets/widget_explicit_flight_primary_attack.png) | Did not load on Thunder Client |
+| widget_explicit_flight_secondary_attack |![](https://assets.open.mp/widgets/widget_explicit_flight_secondary_attack.png) | Did not load on Thunder Client |
+| widget_explicit_jump |![](https://assets.open.mp/widgets/widget_explicit_jump.png) | Did not load on Thunder Client |
+| widget_explicit_look_back_keyboard |![](https://assets.open.mp/widgets/widget_explicit_look_back_keyboard.png) | Did not load on Thunder Client |
+| widget_explicit_look_x |![](https://assets.open.mp/widgets/widget_explicit_look_x.png) | Did not load on Thunder Client |
+| widget_explicit_move_x |![](https://assets.open.mp/widgets/widget_explicit_move_x.png) | Did not load on Thunder Client |
+| widget_explicit_next_weapon |![](https://assets.open.mp/widgets/widget_explicit_next_weapon.png) | Did not load on Thunder Client |
+| widget_explicit_prev_weapon |![](https://assets.open.mp/widgets/widget_explicit_prev_weapon.png) | Did not load on Thunder Client |
+| widget_explicit_punch |![](https://assets.open.mp/widgets/widget_explicit_punch.png) | |
+| widget_explicit_shoot |![](https://assets.open.mp/widgets/widget_explicit_shoot.png) | |
+| widget_explicit_take_cover_left |![](https://assets.open.mp/widgets/widget_explicit_take_cover_left.png) | Did not load on Thunder Client |
+| widget_explicit_take_cover_right |![](https://assets.open.mp/widgets/widget_explicit_take_cover_right.png) | Did not load on Thunder Client |
+| widget_explicit_throw |![](https://assets.open.mp/widgets/widget_explicit_throw.png) | |
+| widget_explicit_toggle_landing_gear |![](https://assets.open.mp/widgets/widget_explicit_toggle_landing_gear.png) | Did not load on Thunder Client |
+| widget_gambling_continue |![](https://assets.open.mp/widgets/widget_gambling_continue.png) | |
+| widget_gambling_quit |![](https://assets.open.mp/widgets/widget_gambling_quit.png) | |
+| widget_gang_follow |![](https://assets.open.mp/widgets/widget_gang_follow.png) | |
+| widget_gang_hold |![](https://assets.open.mp/widgets/widget_gang_hold.png) | |
+| widget_gang_recruit |![](https://assets.open.mp/widgets/widget_gang_recruit.png) | |
+| widget_gift |![](https://assets.open.mp/widgets/widget_gift.png) | |
+| widget_grab |![](https://assets.open.mp/widgets/widget_grab.png) | |
+| widget_gym_easier |![](https://assets.open.mp/widgets/widget_gym_easier.png) | |
+| widget_gym_harder |![](https://assets.open.mp/widgets/widget_gym_harder.png) | |
+| widget_handbrake |![](https://assets.open.mp/widgets/widget_handbrake.png) | |
+| widget_helicopter_magnet_down |![](https://assets.open.mp/widgets/widget_helicopter_magnet_down.png) | |
+| widget_helicopter_magnet_up |![](https://assets.open.mp/widgets/widget_helicopter_magnet_up.png) | |
+| widget_horn |![](https://assets.open.mp/widgets/widget_horn.png) | |
+| widget_hydraulics |![](https://assets.open.mp/widgets/widget_hydraulics.png) | |
+| widget_itb_exit |![](https://assets.open.mp/widgets/widget_itb_exit.png) | Did not load on Thunder Client |
+| widget_kiss |![](https://assets.open.mp/widgets/widget_kiss.png) | |
+| widget_look_left |![](https://assets.open.mp/widgets/widget_look_left.png) | Did not load on Thunder Client |
+| widget_look_right |![](https://assets.open.mp/widgets/widget_look_right.png) | Did not load on Thunder Client |
+| widget_magnet |![](https://assets.open.mp/widgets/widget_magnet.png) | |
+| widget_minigame_cancel |![](https://assets.open.mp/widgets/widget_minigame_cancel.png) | |
+| widget_minigame_start |![](https://assets.open.mp/widgets/widget_minigame_start.png) | |
+| widget_mission_cancel |![](https://assets.open.mp/widgets/widget_mission_cancel.png) | |
+| widget_mission_cancel_vigilante |![](https://assets.open.mp/widgets/widget_mission_cancel_vigilante.png) | |
+| widget_mission_start |![](https://assets.open.mp/widgets/widget_mission_start.png) | |
+| widget_mission_start_vigilante |![](https://assets.open.mp/widgets/widget_mission_start_vigilante.png) | |
+| widget_nitro |![](https://assets.open.mp/widgets/widget_nitro.png) | |
+| widget_ped_move |![](https://assets.open.mp/widgets/widget_ped_move.png) | Did not load on Thunder Client |
+| widget_ped_move_down |![](https://assets.open.mp/widgets/widget_ped_move_down.png) | Did not load on Thunder Client |
+| widget_ped_move_left |![](https://assets.open.mp/widgets/widget_ped_move_left.png) | Did not load on Thunder Client |
+| widget_ped_move_right |![](https://assets.open.mp/widgets/widget_ped_move_right.png) | Did not load on Thunder Client |
+| widget_ped_move_up |![](https://assets.open.mp/widgets/widget_ped_move_up.png) | Did not load on Thunder Client |
+| widget_phone |![](https://assets.open.mp/widgets/widget_phone.png) | |
+| widget_place_bet |![](https://assets.open.mp/widgets/widget_place_bet.png) | |
+| widget_player_info |![](https://assets.open.mp/widgets/widget_player_info.png) | |
+| widget_purchase |![](https://assets.open.mp/widgets/widget_purchase.png) | |
+| widget_race_left |![](https://assets.open.mp/widgets/widget_race_left.png) | |
+| widget_race_right |![](https://assets.open.mp/widgets/widget_race_right.png) | |
+| widget_radar |![](https://assets.open.mp/widgets/widget_radar.png) | |
+| widget_remove_bet |![](https://assets.open.mp/widgets/widget_remove_bet.png) | |
+| widget_reply_no |![](https://assets.open.mp/widgets/widget_reply_no.png) | |
+| widget_reply_yes |![](https://assets.open.mp/widgets/widget_reply_yes.png) | |
+| widget_rhythm_exit |![](https://assets.open.mp/widgets/widget_rhythm_exit.png) | |
+| widget_rocket |![](https://assets.open.mp/widgets/widget_rocket.png) | |
+| widget_roulette_down |![](https://assets.open.mp/widgets/widget_roulette_down.png) | |
+| widget_roulette_left |![](https://assets.open.mp/widgets/widget_roulette_left.png) | |
+| widget_roulette_right |![](https://assets.open.mp/widgets/widget_roulette_right.png) | |
+| widget_roulette_up |![](https://assets.open.mp/widgets/widget_roulette_up.png) | |
+| widget_school_continue |![](https://assets.open.mp/widgets/widget_school_continue.png) | |
+| widget_school_exit |![](https://assets.open.mp/widgets/widget_school_exit.png) | Did not load on Thunder Client |
+| widget_school_left |![](https://assets.open.mp/widgets/widget_school_left.png) | |
+| widget_school_right |![](https://assets.open.mp/widgets/widget_school_right.png) | |
+| widget_skip_cutscene |![](https://assets.open.mp/widgets/widget_skip_cutscene.png) | |
+| widget_sprint |![](https://assets.open.mp/widgets/widget_sprint.png) | |
+| widget_stinger |![](https://assets.open.mp/widgets/widget_stinger.png) | |
+| widget_store_accept |![](https://assets.open.mp/widgets/widget_store_accept.png) | |
+| widget_store_back |![](https://assets.open.mp/widgets/widget_store_back.png) | |
+| widget_store_buy |![](https://assets.open.mp/widgets/widget_store_buy.png) | |
+| widget_store_cancel |![](https://assets.open.mp/widgets/widget_store_cancel.png) | |
+| widget_swap_weapons |![](https://assets.open.mp/widgets/widget_swap_weapons.png) | |
+| widget_swipe_radio_down |![](https://assets.open.mp/widgets/widget_swipe_radio_down.png) | Did not load on Thunder Client |
+| widget_swipe_radio_up |![](https://assets.open.mp/widgets/widget_swipe_radio_up.png) | Did not load on Thunder Client |
+| widget_tap_meter_button |![](https://assets.open.mp/widgets/widget_tap_meter_button.png) | |
+| widget_thumb_circle |![](https://assets.open.mp/widgets/widget_thumb_circle.png) | Did not load on Thunder Client |
+| widget_train_next_station |![](https://assets.open.mp/widgets/widget_train_next_station.png) | |
+| widget_vc_shoot |![](https://assets.open.mp/widgets/widget_vc_shoot.png) | |
+| widget_vehicle_bomb |![](https://assets.open.mp/widgets/widget_vehicle_bomb.png) | |
+| widget_vehicle_shoot_left |![](https://assets.open.mp/widgets/widget_vehicle_shoot_left.png) | |
+| widget_vehicle_shoot_right |![](https://assets.open.mp/widgets/widget_vehicle_shoot_right.png) | |
+| widget_vehicle_steer_left |![](https://assets.open.mp/widgets/widget_vehicle_steer_left.png) | |
+| widget_vehicle_steer_right |![](https://assets.open.mp/widgets/widget_vehicle_steer_right.png) | |
+| widget_vehicle_turret_left |![](https://assets.open.mp/widgets/widget_vehicle_turret_left.png) | |
+| widget_vehicle_turret_right |![](https://assets.open.mp/widgets/widget_vehicle_turret_right.png) | |
+| widget_video_poker_exit |![](https://assets.open.mp/widgets/widget_video_poker_exit.png) | |
+| widget_zoom_in |![](https://assets.open.mp/widgets/widget_zoom_in.png) | |
+| widget_zoom_out |![](https://assets.open.mp/widgets/widget_zoom_out.png) | Did not load on Thunder Client |

--- a/frontend/docs/scripting/resources/android-widgets.md
+++ b/frontend/docs/scripting/resources/android-widgets.md
@@ -12,7 +12,7 @@ Mainly used by [GameText](../functions/GameTextForPlayer), [GameTextForAll](../f
 :::caution
 
 Attempting to show one of this widgets to a PC player will show either some corrupted text or a error saying there's a mismatch in the tildes in the text.
-When it shows the corrupted text, the PC client appears to try to find the resource for the widget, but fails since it doesn't exits.
+When it shows the corrupted text, the PC client appears to try to find the resource for the widget, but fails since it doesn't exists.
 
 :::
 

--- a/frontend/docs/scripting/resources/gametextstyles.md
+++ b/frontend/docs/scripting/resources/gametextstyles.md
@@ -59,6 +59,7 @@ Unlike text colors, these slugs do not require encapsulation. They can be used a
 | `~>~` | Right arrow (gray)                                                                                                                                                                 |
 | `~]~` | Displays a `*` symbol (Only in text styles 3, 4 and 5)                                                                                                                             |
 | `~k~` | Keyboard key mapping (e.g. `~k~~VEHICLE_TURRETLEFT~` and `~k~~PED_FIREWEAPON~`). Look [here](keys) for a list of keys.                                                             |
+| `~m~` | Android button widget (e.g. `~m~~widget_brake~` and `~m~~widget_camera~`). Look [here](android-widgets) for a list of widgets.                                                             |
 
 :::caution
 


### PR DESCRIPTION
Adds a page that includes a list of Android Widgets (UI buttons) that are rendered directly in text, similar to GameText colors:

<img width="2712" height="1220" alt="image" src="https://github.com/user-attachments/assets/f9fe870d-b69a-4e1f-a5fd-5cb130b9281f" />

Should stay unmerged until widgets are added to assets.open.mp and a commit is made to change the URL in the doc file.